### PR TITLE
feat: rename project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
 
 workflows:
   version: 2
-  'graphql-santa':
+  'main':
     jobs:
       - node-latest
       - node-12

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
-For **feature requests**, please fill out the [feature request template](https://github.com/prisma-labs/graphql-santa/issues/new?template=feature.md)
+For **feature requests**, please fill out the [feature request template](https://github.com/graphql-nexus/nexus-future/issues/new?template=feature.md)
 
 ---
 
-For **bug reports**, please fill out the [bug report issue template](https://github.com/prisma-labs/graphql-santa/issues/new?template=bug.md)
+For **bug reports**, please fill out the [bug report issue template](https://github.com/graphql-nexus/nexus-future/issues/new?template=bug.md)

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -10,12 +10,12 @@ assignees: ''
 <!-- 1. Remove sections/details you do not complete -->
 <!-- 2. Add sections/details useful to you -->
 
-|                    |                      |
-| ------------------ | -------------------- |
-| repro              | [link](https://todo) |
-| `node` version     | `...`                |
-| `santa` version    | `...`                |
-| OS and its version | `...`                |
+|                        |                      |
+| ---------------------- | -------------------- |
+| repro                  | [link](https://todo) |
+| `node` version         | `...`                |
+| `nexus-future` version | `...`                |
+| OS and its version     | `...`                |
 
 #### Description
 

--- a/README.md
+++ b/README.md
@@ -145,12 +145,12 @@ yarn -s release:stable
 
 #### Working With Example Apps via Linking
 
-Refer to https://github.com/prisma-labs/graphql-santa-examples
+Refer to https://github.com/graphql-nexus/nexus-future-examples
 
 #### Working with create command
 
 In any example you can use this workflow:
 
 ```
-rm -rf test-create && mcd test-create && ../node_modules/.bin/graphql-santa create
+rm -rf test-create && mcd test-create && ../node_modules/.bin/nexus-future create
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,13 @@
 # Introduction
 
-`graphql-santa` (henceforth referred to as `santa`) is a framework for building GraphQL APIs in Node.
+`nexus-future` is a framework for building GraphQL APIs in Node.
 
-Here are some of the things `santa` cares about:
+Here are some of the things `nexus-future` cares about:
 
 - Delightful developer experience
 - A CLI supporting devlopment lifecycle workflows
 - A deep plugin system for both runtime and CLI
 - Type-Safety across your entire codebase
-- Runtime performance
 - Integration Testing
 
 ## Hello World Example {docsify-ignore}
@@ -16,7 +15,7 @@ Here are some of the things `santa` cares about:
 Here is what a hello world looks like:
 
 ```ts
-import { app } from 'graphql-santa'
+import { app } from 'nexus-future'
 
 app.queryType({
   definition(t) {

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -1,18 +1,18 @@
 # 🎄
 
-# `graphql-santa`
+# `nexus-future`
 
 ### Delightful GraphQL Application Framework for TypeScript Node
 
 <br>
 
 ```cli
-npx graphql-santa
+npx nexus-future
 ```
 
 <br>
 
-[Github](https://github.com/prisma-labs/graphql-santa)
+[Github](https://github.com/graphql-nexus/nexus-future)
 [Docs](/README)
 
 <!-- background color -->

--- a/docs/community/plugins.md
+++ b/docs/community/plugins.md
@@ -1,9 +1,9 @@
 ## `prisma`
 
-[`github`](https://github.com/prisma-labs/graphql-santa-plugin-prisma) [`issues`](https://github.com/prisma-labs/graphql-santa-plugin-prisma/issues)
+[`github`](https://github.com/graphql-nexus/plugin-prisma) [`issues`](https://github.com/graphql-nexus/plugin-prisma/issues)
 
 ```cli
-npm install graphql-santa-plugin-prisma
+npm install nexus-plugin-prisma
 ```
 
 Prisma is a next-generation developer-centric toolkit focused on making the data layer easy.

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -21,7 +21,7 @@
 Kick off a new project. Say yes (`y`) to the prisma option. Choose `PostgreSQL` for the db option.
 
 ```cli
-npx graphql-santa
+npx nexus-future
 ```
 
 ## Change the Data Layer
@@ -46,7 +46,7 @@ Start by updating our data layer to model information about moons. We don't want
 + }
 ```
 
-`graphql-santa` reacts to changes in your Prisma schema. By saving the above, your dev database will be automatically migrated and photon regenerated. You literally now just move on to updating your GraphQL API.
+`nexus-future` reacts to changes in your Prisma schema. By saving the above, your dev database will be automatically migrated and photon regenerated. You literally now just move on to updating your GraphQL API.
 
 ## Change the API Layer
 
@@ -159,7 +159,7 @@ For this step, create an account at [Heroku](https://www.heroku.com/) and [setup
 1.  Add a postgres database to it: `heroku addons:create heroku-postgresql --app <app-name>`
 1.  Get the postgres database credentials: `heroku pg:credentials:url --app <app-name>`
 1.  Export the connection URL into your shell `export DATABASE_URL="<connection-url>"`
-1.  Initialize the postgres database: `npx graphql-santa db init`
+1.  Initialize the postgres database: `npx nexus-future db init`
 1.  Deploy using the git push to master workflow. See your app running in the cloud!
 
 ## Next Steps

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,1 +1,1 @@
-`santa` does not yet have a configuration system. We are working on its design in [#297](https://github.com/prisma-labs/graphql-santa/issues/297).
+`nexus-future` does not yet have a configuration system. We are working on its design in [#297](https://github.com/graphql-nexus/nexus-future/issues/297).

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -1,13 +1,13 @@
-[`issues`](https://github.com/prisma-labs/graphql-santa/labels/scope%2Flogger) ([`feature`](https://github.com/prisma-labs/graphql-santa/issues?q=is%3Aopen+label%3Ascope%2Flogger+label%3Atype%2Ffeature), [`bug`](https://github.com/prisma-labs/graphql-santa/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Flogger+label%3Atype%2Fbug+))
+[`issues`](https://github.com/graphql-nexus/nexus-future/labels/scope%2Flogger) ([`feature`](https://github.com/graphql-nexus/nexus-future/issues?q=is%3Aopen+label%3Ascope%2Flogger+label%3Atype%2Ffeature), [`bug`](https://github.com/graphql-nexus/nexus-future/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Flogger+label%3Atype%2Fbug+))
 
-Logging is one of the primary means for knowing what is going on at runtime, what data is flowing through, and how so. A classic workhorse of debugging and development time feedback. There are a wealth of specialized tools but a great logging strategy can take you far. `santa` gives you a logging system built for a modern cloud native environment.
+Logging is one of the primary means for knowing what is going on at runtime, what data is flowing through, and how so. A classic workhorse of debugging and development time feedback. There are a wealth of specialized tools but a great logging strategy can take you far. `nexus-future` gives you a logging system built for a modern cloud native environment.
 
-It is recommended that your app only sends to stdout via the santa logging system. This ensures that you maintain log level control and are always working with JSON. We work hard to make the logger so good that you'll to use it.
+It is recommended that your app only sends to stdout via the nexus-future logging system. This ensures that you maintain log level control and are always working with JSON. We work hard to make the logger so good that you'll to use it.
 
 - Applications can get a reference to a logger singleton at `app.logger`.
 
   ```ts
-  import { app } from 'graphql-santa'
+  import { app } from 'nexus-future'
 
   app.logger.info('hello')
   ```
@@ -71,7 +71,7 @@ It is recommended that your app only sends to stdout via the santa logging syste
 - Pretty mode looks something like this:
 
   ```
-  ● info  santa:dev:boot
+  ● info  nexus-future:dev:boot
   ● info  app:boot
 
   ------------
@@ -94,7 +94,7 @@ You can create child loggers recursively starting from the root logger. A child 
 
 Child loggers are useful when you want to pass a logger to something that should be tracked as its own subsystem and/or may add context that you want isolated from the rest of the system. For example a classic use-case is the logger-instance-per-request pattern where a request-scoped logger is used for all logs in a request-response code path. This makes it much easier in production to group logs in your logging platform by request-response lifecycles.
 
-All runtime logs in your app (including from plugins ([bug #300](https://github.com/prisma-labs/graphql-santa/issues/300))) come from either the `app.logger` itself or descendents thereof. This means if you wish absolutely every log being emitted by your app to contain some additional context you can do so simply by adding context to the root logger:
+All runtime logs in your app (including from plugins ([bug #300](https://github.com/graphql-nexus/nexus-future/issues/300))) come from either the `app.logger` itself or descendents thereof. This means if you wish absolutely every log being emitted by your app to contain some additional context you can do so simply by adding context to the root logger:
 
 ```ts
 app.logger.addToContext({ user: 'Toto' })
@@ -108,4 +108,4 @@ app.logger
 
 ## debug Tool Integration
 
-You may be a user of [`debug`](https://github.com/visionmedia/debug) or install libraries into your app that are. We (_will ↣_ [#265](https://github.com/prisma-labs/graphql-santa/issues/265)) have special case support for `debug` so that it seamlessly integrates into the santa logging system. The gist is that all `debug` logs are routed through the `santa` logger at `trace` level.
+You may be a user of [`debug`](https://github.com/visionmedia/debug) or install libraries into your app that are. We (_will ↣_ [#265](https://github.com/graphql-nexus/nexus-future/issues/265)) have special case support for `debug` so that it seamlessly integrates into the nexus-future logging system. The gist is that all `debug` logs are routed through the `nexus-future` logger at `trace` level.

--- a/docs/guides/writing-plugins.md
+++ b/docs/guides/writing-plugins.md
@@ -1,65 +1,66 @@
-[`issues`](https://github.com/prisma-labs/graphql-santa/labels/scope%2Fplugins) ([`feature`](https://github.com/prisma-labs/graphql-santa/issues?q=is%3Aopen+label%3Ascope%2Fplugins+label%3Atype%2Ffeature), [`bug`](https://github.com/prisma-labs/graphql-santa/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fplugins+label%3Atype%2Fbug+))
+[`issues`](https://github.com/graphql-nexus/nexus-future/labels/scope%2Fplugins) ([`feature`](https://github.com/graphql-nexus/nexus-future/issues?q=is%3Aopen+label%3Ascope%2Fplugins+label%3Atype%2Ffeature), [`bug`](https://github.com/graphql-nexus/nexus-future/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fplugins+label%3Atype%2Fbug+))
 
 ## Here Be Dragons
 
-- Writing plugins is an expressive and exciting part of the santa framework
+- Writing plugins is an expressive and exciting part of the nexus-future framework
 - But please note that it is one of the least stable components
 - Not just in terms of lack of polish or unstable APIs but entire concepts and architecture
 - The bar to a finished stable plugin system is high not just because plugin systems are in general challenging, but also because the thing which it permits extending is itself not stable either: the framework components exposed at the application layer
-- If you are embarking on creating a plugin, please be aware you are in uncharted territory with no guarantees about API stability or even entire concepts/ways of extending santa
+- If you are embarking on creating a plugin, please be aware you are in uncharted territory with no guarantees about API stability or even entire concepts/ways of extending nexus-future
 - If you are ok with that, we welcome you aboard this journey and hope you share your feedback with the team on GitHub and creations with the community on slack!
 
 ## How it Looks
 
-- `santa` CLI has a command to create new santa plugin projects
+- `nexus-future` CLI has a command to create new nexus-future plugin projects
   ```cli
-  npx santa create plugin
+  npx nexus-future create plugin
   ```
 - To write a plugin you import from the plugin module
   ```ts
-  import * as SantaPlugin from 'graphql-santa/plugin'
+  import * as nexus-futurePlugin from 'nexus-future/plugin'
   ```
 - Use the `create` function to build your plugin
 
   ```ts
-  import * as SantaPlugin from 'graphql-santa/plugin'
+  import * as nexus-futurePlugin from 'nexus-future/plugin'
 
-  SantaPlugin.create(() => { ... })
+  nexus-futurePlugin.create(() => { ... })
   ```
 
 - Export your plugin as default from your package entrypoint
 
   ```ts
-  export default SantaPlugin.create(() => { ... })
+  export default nexus-futurePlugin.create(() => { ... })
   ```
 
-- Your callback will be passed an api to hook into santa
+- Your callback will be passed an api to hook into nexus-future
 
   ```ts
-  export default SantaPlugin.create(project => { ... })
+  export default nexus-futurePlugin.create(project => { ... })
   ```
 
-- You can hook into the runtime or the worktime ([todo](https://github.com/prisma-labs/graphql-santa/issues/294))
+- You can hook into the runtime or the worktime ([todo](https://github.com/graphql-nexus/nexus-future/issues/294))
 
   ```ts
-  export default SantaPlugin.create(project => {
+  export default nexus-futurePlugin.create(project => {
     project.worktime(() => { ... })
     project.runtime(() => { ... })
   })
   ```
 
-- You have access to project utils ([todo](https://github.com/prisma-labs/graphql-santa/issues/282))
+- You have access to project utils ([todo](https://github.com/graphql-nexus/nexus-future/issues/282))
 
   ```ts
-  export default SantaPlugin.create(project => {
-    project.utils.logger.trace('hello')
-  })
+  export default nexus -
+    futurePlugin.create(project => {
+      project.utils.logger.trace('hello')
+    })
   ```
 
 - At runtime you can pass configuration to `nexus` and contribute toward the graphql resolver context:
 
   ```ts
-  export default SantaPlugin.create(project => {
+  export default nexus-futurePlugin.create(project => {
     project.runtime(() => {
       return {
         context: {
@@ -86,7 +87,7 @@
 - At worktime you can hook onto various events grouped by subsystem:
 
   ```ts
-  export default SantaPlugin.create(project => {
+  export default nexus-futurePlugin.create(project => {
     project.worktime(hooks => {
       // Not all hooks shown here
       hooks.build.onStart = async () => { ... }
@@ -107,23 +108,24 @@
 - Some worktime hooks give you contextual information to reflect upon:
 
   ```ts
-  export default SantaPlugin.create(project => {
-    project.worktime(hooks => {
-      hooks.db.plan.onStart = async hctx => {
-        project.logger.info(hctx.migrationName)
-      }
+  export default nexus -
+    futurePlugin.create(project => {
+      project.worktime(hooks => {
+        hooks.db.plan.onStart = async hctx => {
+          project.logger.info(hctx.migrationName)
+        }
+      })
     })
-  })
   ```
 
 ## Wholistic
 
-- The breadth of santa's plugin system is uncommon
+- The breadth of nexus-future's plugin system is uncommon
 - Most tools are either rutime (Express) or workflow (ESLint) oriented and thus naturally scope their plugins to their focus
-- the advantage of santa's approach where plugins can hook into both workflow and runtime is that they allow plugin authors to deliver rich wholistic experiences for their users
+- the advantage of nexus-future's approach where plugins can hook into both workflow and runtime is that they allow plugin authors to deliver rich wholistic experiences for their users
 - For example a plugin author might reinforce their plugin's runtime feature with additions to doctor which lint for idiomatic usage
 - No longer does a plugin need rely on a lengthy readme that probably isn't complete and probably isn't read by most users to guide users through correct configuration, etc. usage of their plugin
-- `santa` is fanatic about giving as much latitude as possible to plugin authors to craft plugins that forward the principal of the pit of success to santa app developers
+- `nexus-future` is fanatic about giving as much latitude as possible to plugin authors to craft plugins that forward the principal of the pit of success to nexus-future app developers
 
 ## Runtime vs Worktime
 
@@ -134,12 +136,12 @@
 
 ## Publishing for Consumption
 
-- You must name your plugin package `graphql-santa-plugin-<your-plugin-name>`
-- `santa` plugin cli will rely on this convention to search install etc. plugins ([todo](https://github.com/prisma-labs/graphql-santa/issues/155))
-- `santa` relies on this pattern to auto-use plugins in a user's project
+- You must name your plugin package `nexus-plugin-<your-plugin-name>`
+- `nexus-future` plugin cli will rely on this convention to search install etc. plugins ([todo](https://github.com/graphql-nexus/nexus-future/issues/155))
+- `nexus-future` relies on this pattern to auto-use plugins in a user's project
 
 ## A Code Reference
 
-- The most sophisticated real-world santa plugin is prisma.
-- It currently drives many of the requirements of the plugin system where we want santa-prisma users to feel prisma is as seamless a component as any core one.
-- If you like learning by reading code, check it out here: [prisma-labs/graphql-santa-plugin-prisma](https://github.com/prisma-labs/graphql-santa-plugin-prisma).
+- The most sophisticated real-world nexus-future plugin is prisma.
+- It currently drives many of the requirements of the plugin system where we want nexus-future-prisma users to feel prisma is as seamless a component as any core one.
+- If you like learning by reading code, check it out here: [graphql-nexus/plugin-prisma](https://github.com/graphql-nexus/plugin-prisma).

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>graphql-santa</title>
+    <title>nexus-future</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="description" content="Description" />
     <meta
@@ -208,7 +208,7 @@
         coverpage: true,
         // onlyCover: true,
         name: '🎄',
-        repo: 'prisma-labs/graphql-santa',
+        repo: 'graphql-nexus/nexus-future',
         subMaxLevel: 3,
         loadSidebar: true,
         autoHeader: true,

--- a/docs/references/api.md
+++ b/docs/references/api.md
@@ -1,13 +1,13 @@
 ## `app`
 
-A singleton graphql-santa app. Use this to build up your GraphQL schema and configure your server.
+A singleton nexus-future app. Use this to build up your GraphQL schema and configure your server.
 
 **Example**
 
 ```ts
 // schema.ts
 
-import { app } from 'graphql-santa'
+import { app } from 'nexus-future'
 
 app.objectType({
   name: 'Foo',
@@ -26,7 +26,7 @@ Add context to your graphql resolver functions. The objects returned by your con
 ```ts
 // app.ts
 
-import { app } from 'graphql-santa'
+import { app } from 'nexus-future'
 
 app.addToContext(req => {
   return {
@@ -51,7 +51,7 @@ Add types to your GraphQL Schema. The available nexus definition block functions
 ```ts
 // schema.ts
 
-import { app } from 'graphql-santa'
+import { app } from 'nexus-future'
 
 app.objectType({
   name: 'Foo',
@@ -70,7 +70,7 @@ An instance of [`RootLogger`](#rootlogger).
 ```ts
 // app.ts
 
-import { app } from 'graphql-santa'
+import { app } from 'nexus-future'
 
 app.logger.info('boot')
 ```
@@ -81,7 +81,7 @@ An instance of [`Server`](#server).
 
 Framework Notes:
 
-- If your app does not call `app.server.start` then `santa` will. It is idiomatic to allow `santa` to take care of this. If you deviate, we would love to learn about your use-case!
+- If your app does not call `app.server.start` then `nexus-future` will. It is idiomatic to allow `nexus-future` to take care of this. If you deviate, we would love to learn about your use-case!
 
 ## `Server`
 

--- a/docs/references/cli.md
+++ b/docs/references/cli.md
@@ -1,5 +1,5 @@
 ## TODO
 
 ```cli
-santa --help
+nexus-future --help
 ```

--- a/docs/references/components.md
+++ b/docs/references/components.md
@@ -1,12 +1,12 @@
 ## HTTP Server
 
-[`issues`](https://github.com/prisma-labs/graphql-santa/labels/scope%2Fserver) ([`feature`](https://github.com/prisma-labs/graphql-santa/issues?q=is%3Aopen+label%3Ascope%2Fserver+label%3Atype%2Ffeature), [`bug`](https://github.com/prisma-labs/graphql-santa/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fserver+label%3Atype%2Fbug+))
+[`issues`](https://github.com/graphql-nexus/nexus-future/labels/scope%2Fserver) ([`feature`](https://github.com/graphql-nexus/nexus-future/issues?q=is%3Aopen+label%3Ascope%2Fserver+label%3Atype%2Ffeature), [`bug`](https://github.com/graphql-nexus/nexus-future/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fserver+label%3Atype%2Fbug+))
 
 ### About {docsify-ignore}
 
-This component handles recieving requests and sending responses to your clients. It is the transport layer, which GraphQL itself is actually agnostic about. Simple apps will not need to deal with this component directly as `santa` automatically runs it by default.
+This component handles recieving requests and sending responses to your clients. It is the transport layer, which GraphQL itself is actually agnostic about. Simple apps will not need to deal with this component directly as `nexus-future` automatically runs it by default.
 
-We currently use [`express-graphql`](https://github.com/graphql/express-graphql). There is an [open issue](https://github.com/prisma-labs/graphql-santa/issues/231) about adopting [`fastify-gql`](https://github.com/mcollina/fastify-gql) instead.
+We currently use [`express-graphql`](https://github.com/graphql/express-graphql). There is an [open issue](https://github.com/graphql-nexus/nexus-future/issues/231) about adopting [`fastify-gql`](https://github.com/mcollina/fastify-gql) instead.
 
 ### Features {docsify-ignore}
 
@@ -14,7 +14,7 @@ TODO
 
 ## GraphQL Schema
 
-[`issues`](https://github.com/prisma-labs/graphql-santa/labels/scope%2Fgql) ([`feature`](https://github.com/prisma-labs/graphql-santa/issues?q=is%3Aopen+label%3Ascope%2Fgql+label%3Atype%2Ffeature), [`bug`](https://github.com/prisma-labs/graphql-santa/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fgql+label%3Atype%2Fbug+))
+[`issues`](https://github.com/graphql-nexus/nexus-future/labels/scope%2Fgql) ([`feature`](https://github.com/graphql-nexus/nexus-future/issues?q=is%3Aopen+label%3Ascope%2Fgql+label%3Atype%2Ffeature), [`bug`](https://github.com/graphql-nexus/nexus-future/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fgql+label%3Atype%2Fbug+))
 
 ### About {docsify-ignore}
 
@@ -28,13 +28,13 @@ TODO
 
 ## Builder
 
-[`issues`](https://github.com/prisma-labs/graphql-santa/labels/scope%2Fbuilder) ([`feature`](https://github.com/prisma-labs/graphql-santa/issues?q=is%3Aopen+label%3Ascope%2Fbuilder+label%3Atype%2Ffeature), [`bug`](https://github.com/prisma-labs/graphql-santa/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fbuilder+label%3Atype%2Fbug+))
+[`issues`](https://github.com/graphql-nexus/nexus-future/labels/scope%2Fbuilder) ([`feature`](https://github.com/graphql-nexus/nexus-future/issues?q=is%3Aopen+label%3Ascope%2Fbuilder+label%3Atype%2Ffeature), [`bug`](https://github.com/graphql-nexus/nexus-future/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fbuilder+label%3Atype%2Fbug+))
 
 ### About {docsify-ignore}
 
 The part where you build your app into something ready for deployment to production.
 
-We use [TypeScript](https://github.com/microsoft/TypeScript). We [plan](https://github.com/prisma-labs/graphql-santa/issues/119) to introduce a bundle step as well.
+We use [TypeScript](https://github.com/microsoft/TypeScript). We [plan](https://github.com/graphql-nexus/nexus-future/issues/119) to introduce a bundle step as well.
 
 ### Features {docsify-ignore}
 
@@ -42,11 +42,11 @@ TODO
 
 ## Database
 
-[`issues`](https://github.com/prisma-labs/graphql-santa/labels/scope%2Fdatabase) ([`feature`](https://github.com/prisma-labs/graphql-santa/issues?q=is%3Aopen+label%3Ascope%2Fdatabase+label%3Atype%2Ffeature), [`bug`](https://github.com/prisma-labs/graphql-santa/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fdatabase+label%3Atype%2Fbug+))
+[`issues`](https://github.com/graphql-nexus/nexus-future/labels/scope%2Fdatabase) ([`feature`](https://github.com/graphql-nexus/nexus-future/issues?q=is%3Aopen+label%3Ascope%2Fdatabase+label%3Atype%2Ffeature), [`bug`](https://github.com/graphql-nexus/nexus-future/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fdatabase+label%3Atype%2Fbug+))
 
 ### About {docsify-ignore}
 
-Many applications need to persist data, but doing so often brings on more complexity. Deployments are harder, accurate local development environments are more involved, integration tests become more complex to write and slower, ... and so on. `santa` tackles this complexity by standardizing a database driver system that makes it possible to integrate database workflows seamlessly into your project.
+Many applications need to persist data, but doing so often brings on more complexity. Deployments are harder, accurate local development environments are more involved, integration tests become more complex to write and slower, ... and so on. `nexus-future` tackles this complexity by standardizing a database driver system that makes it possible to integrate database workflows seamlessly into your project.
 
 ### Features {docsify-ignore}
 
@@ -55,7 +55,7 @@ Many applications need to persist data, but doing so often brings on more comple
 
 ## Dev
 
-[`issues`](https://github.com/prisma-labs/graphql-santa/labels/scope%2Fdev) ([`feature`](https://github.com/prisma-labs/graphql-santa/issues?q=is%3Aopen+label%3Ascope%2Fdev+label%3Atype%2Ffeature), [`bug`](https://github.com/prisma-labs/graphql-santa/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fdev+label%3Atype%2Fbug+))
+[`issues`](https://github.com/graphql-nexus/nexus-future/labels/scope%2Fdev) ([`feature`](https://github.com/graphql-nexus/nexus-future/issues?q=is%3Aopen+label%3Ascope%2Fdev+label%3Atype%2Ffeature), [`bug`](https://github.com/graphql-nexus/nexus-future/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fdev+label%3Atype%2Fbug+))
 
 ### About {docsify-ignore}
 
@@ -70,11 +70,11 @@ In development you want a variety of features that make it easy to work on and t
 
 ## Logger
 
-[`issues`](https://github.com/prisma-labs/graphql-santa/labels/scope%2Flogger) ([`feature`](https://github.com/prisma-labs/graphql-santa/issues?q=is%3Aopen+label%3Ascope%2Flogger+label%3Atype%2Ffeature), [`bug`](https://github.com/prisma-labs/graphql-santa/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Flogger+label%3Atype%2Fbug+))
+[`issues`](https://github.com/graphql-nexus/nexus-future/labels/scope%2Flogger) ([`feature`](https://github.com/graphql-nexus/nexus-future/issues?q=is%3Aopen+label%3Ascope%2Flogger+label%3Atype%2Ffeature), [`bug`](https://github.com/graphql-nexus/nexus-future/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Flogger+label%3Atype%2Fbug+))
 
 ### About {docsify-ignore}
 
-One of the primary means for knowing what is going on at runtime, what data is flowing through, and how so. A classic workhorse of debugging and development time feedback. There are a wealth of specialized tools but a great logging strategy can take you far. `santa` gives you a logging system built for a modern cloud native environment.
+One of the primary means for knowing what is going on at runtime, what data is flowing through, and how so. A classic workhorse of debugging and development time feedback. There are a wealth of specialized tools but a great logging strategy can take you far. `nexus-future` gives you a logging system built for a modern cloud native environment.
 
 We have our own logger but write to [`pino`](https://github.com/pinojs/pino) under the hood for its performance.
 
@@ -86,7 +86,7 @@ We have our own logger but write to [`pino`](https://github.com/pinojs/pino) und
   **_example_**
 
   ```
-  ● info  santa:dev:boot
+  ● info  nexus-future:dev:boot
   ● info  app:boot
 
   ------------
@@ -109,7 +109,7 @@ We have our own logger but write to [`pino`](https://github.com/pinojs/pino) und
   **_example_**
 
   ```
-  {"level":30,"time":1578887817230,"pid":30997,"hostname":"Jasons-Prisma-Machine.local","path":["santa","dev"],"context":{},"event":"boot","v":1}
+  {"level":30,"time":1578887817230,"pid":30997,"hostname":"Jasons-Prisma-Machine.local","path":["nexus-future","dev"],"context":{},"event":"boot","v":1}
   {"level":30,"time":1578887819619,"pid":30998,"hostname":"Jasons-Prisma-Machine.local","path":["app"],"context":{},"event":"boot","v":1}
   {"level":60,"time":1578887819621,"pid":30998,"hostname":"Jasons-Prisma-Machine.local","path":["app"],"context":{"lib":{}},"event":"foo","v":1}
   {"level":50,"time":1578887819621,"pid":30998,"hostname":"Jasons-Prisma-Machine.local","path":["app"],"context":{"har":{"mar":"tek"}},"event":"foo","v":1}
@@ -129,18 +129,18 @@ We have our own logger but write to [`pino`](https://github.com/pinojs/pino) und
 * Standardizes six log levels: `fatal` `error` `warn` `info` `debug` `trace`  
   **_why_** Give logs more meaning/semantics, helps enable alerting policies, enables keeping production logs lean whilst maintaining higher resolution for development in development.
 
-* (_will ↣_ [#263](https://github.com/prisma-labs/graphql-santa/issues/263)) Exposes the pretty renderer as a CLI  
+* (_will ↣_ [#263](https://github.com/graphql-nexus/nexus-future/issues/263)) Exposes the pretty renderer as a CLI  
   **_why_** Allows you to pipe JSON logs from a remote location thus maintaining the human-readable experience you get in development.
 
-* (_will ↣_ [#265](https://github.com/prisma-labs/graphql-santa/issues/265)) Integrates logs from [`debug`](https://github.com/visionmedia/debug)  
+* (_will ↣_ [#265](https://github.com/graphql-nexus/nexus-future/issues/265)) Integrates logs from [`debug`](https://github.com/visionmedia/debug)  
   **_why_** We make it possible to continue benefiting from the widespread use of this tool in the node community in our structured system.
 
-* (_will ↣_ [#264](https://github.com/prisma-labs/graphql-santa/issues/264)) Interactive filtering on the command line  
+* (_will ↣_ [#264](https://github.com/graphql-nexus/nexus-future/issues/264)) Interactive filtering on the command line  
   **_why_** Keep yourself in the flow by focusing on the logs most relevant to your current development loop; Enjoy `trace` level without an overwhelming firehose; Enjoy isolating your or someone else's plugin logs.
 
 ## CLI
 
-[`issues`](https://github.com/prisma-labs/graphql-santa/labels/scope%2Fcli) ([`feature`](https://github.com/prisma-labs/graphql-santa/issues?q=is%3Aopen+label%3Ascope%2Fcli+label%3Atype%2Ffeature), [`bug`](https://github.com/prisma-labs/graphql-santa/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fcli+label%3Atype%2Fbug+))
+[`issues`](https://github.com/graphql-nexus/nexus-future/labels/scope%2Fcli) ([`feature`](https://github.com/graphql-nexus/nexus-future/issues?q=is%3Aopen+label%3Ascope%2Fcli+label%3Atype%2Ffeature), [`bug`](https://github.com/graphql-nexus/nexus-future/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fcli+label%3Atype%2Fbug+))
 
 ### About {docsify-ignore}
 
@@ -152,7 +152,7 @@ TODO
 
 ## Plugins
 
-[`issues`](https://github.com/prisma-labs/graphql-santa/labels/scope%2Fplugins) ([`feature`](https://github.com/prisma-labs/graphql-santa/issues?q=is%3Aopen+label%3Ascope%2Fplugins+label%3Atype%2Ffeature), [`bug`](https://github.com/prisma-labs/graphql-santa/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fplugins+label%3Atype%2Fbug+))
+[`issues`](https://github.com/graphql-nexus/nexus-future/labels/scope%2Fplugins) ([`feature`](https://github.com/graphql-nexus/nexus-future/issues?q=is%3Aopen+label%3Ascope%2Fplugins+label%3Atype%2Ffeature), [`bug`](https://github.com/graphql-nexus/nexus-future/issues?utf8=%E2%9C%93&q=is%3Aopen+label%3Ascope%2Fplugins+label%3Atype%2Fbug+))
 
 ### About {docsify-ignore}
 

--- a/docs/references/conventions.md
+++ b/docs/references/conventions.md
@@ -20,7 +20,7 @@ Optional –– The entrypoint to your app
 
 There can only be at most a single `app.ts`/`server.ts`/`service.ts` module in your source tree.
 
-This module is optional **when** you just have schema modules and so graphql-santa already knows how import them into the final build. Otherwise you'll need this module to import your custom modules etc.
+This module is optional **when** you just have schema modules and so nexus-future already knows how import them into the final build. Otherwise you'll need this module to import your custom modules etc.
 
 ##### Aliases
 

--- a/docs/references/recipes.md
+++ b/docs/references/recipes.md
@@ -3,7 +3,7 @@
 1. Install the prisma plugin
 
    ```cli
-   npm install graphql-santa-plugin-prisma
+   npm install nexus-plugin-prisma
    ```
 
 1. Add a `schema.prisma` file. Add a datasource. Here we're working with SQLite. Add photon.
@@ -24,7 +24,7 @@
 1. Initialize your database
 
    ```cli
-   npx santa db init
+   npx nexus-future db init
    ```
 
 1. Done. Now your app has:
@@ -32,7 +32,7 @@
    1. Functioning `db` command
 
       ```cli
-      santa db
+      nexus-future db
       ```
 
    1. `nexus-prisma` Nexus plugin allowing e.g.:
@@ -75,7 +75,7 @@
 1. Scaffold Your plugin project
 
    ```cli
-   npx santa create plugin
+   npx nexus-future create plugin
    ```
 
 2. Publish it
@@ -110,7 +110,7 @@ If you don't want to use a docker, here are some links to alternative approaches
 
    ```diff
    +++ package.json
-   + "build": "santa build"
+   + "build": "nexus-future build"
    ```
 
 2. Add a start script
@@ -124,12 +124,12 @@ If you don't want to use a docker, here are some links to alternative approaches
 
    ```diff
    +++ package.json
-   + "build": "santa build --deployment now"
+   + "build": "nexus-future build --deployment now"
    ```
 
    ```diff
    +++ package.json
-   + "build": "santa build --deployment heroku"
+   + "build": "nexus-future build --deployment heroku"
    ```
 
 ## Prisma + Heroku + PostgreSQL
@@ -175,7 +175,7 @@ If you don't want to use a docker, here are some links to alternative approaches
 
    ```ts
    // tests/__helpers.ts
-   import { createTestContext, TestContext } from 'graphql-santa/testing'
+   import { createTestContext, TestContext } from 'nexus-future/testing'
 
    export function createTestContext(): TestContext {
      let ctx: TestContext

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "graphql-santa",
+  "name": "nexus-future",
   "author": "Prisma Labs",
   "version": "0.1.2",
-  "homepage": "https://github.com/prisma-labs/graphql-santa",
-  "repository": "prisma-labs/graphql-santa",
-  "bugs": "https://github.com/prisma-labs/graphql-santa/issues",
+  "homepage": "https://github.com/graphql-nexus/nexus-future",
+  "repository": "graphql-nexus/nexus-future",
+  "bugs": "https://github.com/graphql-nexus/nexus-future/issues",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [
@@ -16,8 +16,7 @@
     "plugin.js"
   ],
   "bin": {
-    "graphql-santa": "dist/cli/main.js",
-    "santa": "dist/cli/main.js"
+    "nexus-future": "dist/cli/main.js"
   },
   "dependencies": {
     "@types/debug": "^4.1.5",

--- a/src/cli/commands/__default.ts
+++ b/src/cli/commands/__default.ts
@@ -1,10 +1,10 @@
-import { Command } from '../../lib/cli'
+import { stripIndent } from 'common-tags'
+import * as fs from 'fs-jetpack'
 import * as Layout from '../../framework/layout'
-import { pog, generateProjectName, CWDProjectNameOrGenerate } from '../../utils'
+import { Command } from '../../lib/cli'
+import { CWDProjectNameOrGenerate, generateProjectName, pog } from '../../utils'
 import { run } from './create/app'
 import { Dev } from './dev'
-import * as fs from 'fs-jetpack'
-import { stripIndent } from 'common-tags'
 
 const log = pog.sub('cli:entrypoint')
 
@@ -16,27 +16,27 @@ export class __Default implements Command {
     switch (projectType.type) {
       case 'new':
         log(
-          'detected CWD is empty and not within an existing graphql-santa project, delegating to create sub-command'
+          'detected CWD is empty and not within an existing nexus-future project, delegating to create sub-command'
         )
-        console.log('Creating a new graphql-santa project')
+        console.log('Creating a new nexus-future project')
         await run({ projectName: CWDProjectNameOrGenerate() })
         break
-      case 'graphql_santa_project':
+      case 'NEXUS_FUTURE_project':
         log(
-          'detected CWD is within a graphql-santa project, delegating to dev mode'
+          'detected CWD is within a nexus-future project, delegating to dev mode'
         )
         await new Dev().parse([])
         break
       case 'node_project':
         log(
-          'detected CWD is within a node but not graphql-santa project, aborting'
+          'detected CWD is within a node but not nexus-future project, aborting'
         )
         console.log(
-          "Looks like you are inside a node but not graphql-santa project. Please either add graphql-santa to this project's dependencies and re-run this command or navigate to a new empty folder that does not have a package.json file present in an anecestor directory."
+          "Looks like you are inside a node but not nexus-future project. Please either add nexus-future to this project's dependencies and re-run this command or navigate to a new empty folder that does not have a package.json file present in an anecestor directory."
         )
         break
       case 'unknown':
-        log('detected CWD is not empty nor a graphql-santa project, aborting')
+        log('detected CWD is not empty nor a nexus-future project, aborting')
         // We can get the user on the happy path by asking them for a project
         // name and then changing into that directory.
         const projectName = generateProjectName()
@@ -58,7 +58,7 @@ export class __Default implements Command {
           NOTE
           ----
 
-          Your new graphql-santa project was created in ${projectName}. Only you can navigate into it:
+          Your new nexus-future project was created in ${projectName}. Only you can navigate into it:
           
             cd ./${projectName}
         `)

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -2,9 +2,10 @@ import { stripIndent } from 'common-tags'
 import * as fs from 'fs-jetpack'
 import ts from 'typescript'
 import { START_MODULE_NAME } from '../../constants'
-import * as Layout from '../../framework/layout'
 import * as Plugin from '../../core/plugin'
+import * as Layout from '../../framework/layout'
 import { createStartModuleContent } from '../../framework/start'
+import { arg, Command, isError } from '../../lib/cli'
 import {
   compile,
   createTSProgram,
@@ -22,7 +23,6 @@ import {
   validateTarget,
 } from '../../utils/deploy-target'
 import { rootLogger } from '../../utils/logger'
-import { arg, Command, isError } from '../../lib/cli'
 
 const logger = rootLogger.child('builder')
 
@@ -73,7 +73,7 @@ export class Build implements Command {
 
     const tsProgram = createTSProgram(layout)
     const contextFieldTypes = extractContextTypes(tsProgram)
-    process.env.GRAPHQL_SANTA_TYPEGEN_ADD_CONTEXT_RESULTS = JSON.stringify(
+    process.env.NEXUS_FUTURE_TYPEGEN_ADD_CONTEXT_RESULTS = JSON.stringify(
       contextFieldTypes
     )
 
@@ -106,9 +106,9 @@ export class Build implements Command {
 
   help() {
     return stripIndent`
-      Usage: graphql-santa build [flags]
+      Usage: nexus-future build [flags]
 
-      Build a production-ready graphql-santa server
+      Build a production-ready nexus-future server
 
       Flags:
         -o,     --output    Relative path to output directory
@@ -120,7 +120,7 @@ export class Build implements Command {
 
 /**
  * Output to disk in the build the start module that will be used to boot the
- * graphql-santa app.
+ * nexus-future app.
  */
 async function writeStartModule(
   buildStage: string,
@@ -133,10 +133,10 @@ async function writeStartModule(
   // their module index.ts.
   if (fs.exists(`${layout.buildOutput}/${START_MODULE_NAME}.js`)) {
     fatal(stripIndent`
-      graphql-santa reserves the source root module name ${START_MODULE_NAME}.js for its own use.
+      nexus-future reserves the source root module name ${START_MODULE_NAME}.js for its own use.
       Please change your app layout to not have this module.
       This is a temporary limitation that we intend to remove in the future. 
-      For more details please see this GitHub issue: https://github.com/prisma-labs/graphql-santa/issues/139
+      For more details please see this GitHub issue: https://github.com/graphql-nexus/nexus-future/issues/139
     `)
   }
 

--- a/src/cli/commands/create/app.ts
+++ b/src/cli/commands/create/app.ts
@@ -2,18 +2,18 @@ import { stripIndent } from 'common-tags'
 import * as fs from 'fs-jetpack'
 import prompts from 'prompts'
 import { PackageJson } from 'type-fest'
-import * as Layout from '../../../framework/layout'
 import * as Plugin from '../../../core/plugin'
+import * as Layout from '../../../framework/layout'
+import { Command } from '../../../lib/cli'
 import {
   createGitRepository,
   createTSConfigContents,
   CWDProjectNameOrGenerate,
-  pog,
   logger,
+  pog,
 } from '../../../utils'
 import * as PackageManager from '../../../utils/package-manager'
 import * as proc from '../../../utils/process'
-import { Command } from '../../../lib/cli'
 
 const log = pog.sub('cli:create:app')
 
@@ -25,14 +25,14 @@ export default class App implements Command {
 
 type Options = {
   projectName: string
-  graphqlSantaVersion: string
+  nexusFutureVersion: string
 }
 
 /**
  * TODO
  */
 export async function run(optionsGiven?: Partial<Options>): Promise<void> {
-  if (process.env.GRAPHQL_SANTA_CREATE_HANDOFF === 'true') {
+  if (process.env.NEXUS_FUTURE_CREATE_HANDOFF === 'true') {
     await runLocalHandOff(optionsGiven)
   } else {
     await runBootstrapper(optionsGiven)
@@ -95,10 +95,10 @@ export async function runBootstrapper(
     ...optionsGiven,
     projectName: CWDProjectNameOrGenerate(),
     // @ts-ignore
-    graphqlSantaVersion: `^${require('../../../../package.json').version}`,
+    nexusFutureVersion: `^${require('../../../../package.json').version}`,
   }
 
-  // TODO in the future scan npm registry for graphql-santa plugins, organize by
+  // TODO in the future scan npm registry for nexus-future plugins, organize by
   // github stars, and so on.
   const askDatabase = await askForDatabase()
 
@@ -106,7 +106,7 @@ export async function runBootstrapper(
   await scaffoldBaseFiles(layout, options)
 
   logger.info(
-    `Installing graphql-santa@${options.graphqlSantaVersion}... (this will take around ~30 seconds)`
+    `Installing nexus-future@${options.nexusFutureVersion}... (this will take around ~30 seconds)`
   )
   await layout.packageManager.installDeps({ require: true })
 
@@ -124,7 +124,7 @@ export async function runBootstrapper(
   )
 
   if (askDatabase.database) {
-    deps.push(`graphql-santa-plugin-prisma@${getPrismaPluginVersion()}`)
+    deps.push(`nexus-plugin-prisma@${getPrismaPluginVersion()}`)
     // This allows installing prisma without a warning being emitted about there
     // being a missing prisma schema. For more detail refer to
     // https://prisma-company.slack.com/archives/CEYCG2MCN/p1575480721184700 and
@@ -164,9 +164,9 @@ export async function runBootstrapper(
   //
 
   await layout.packageManager
-    .runBin('graphql-santa create', {
+    .runBin('nexus-future create', {
       stdio: 'inherit',
-      envAdditions: { GRAPHQL_SANTA_CREATE_HANDOFF: 'true' },
+      envAdditions: { NEXUS_FUTURE_CREATE_HANDOFF: 'true' },
       require: true,
     })
     .catch(error => {
@@ -177,7 +177,7 @@ export async function runBootstrapper(
   // An exhaustive .gitignore tailored for Node can be found here:
   // https://github.com/github/gitignore/blob/master/Node.gitignore
   // We intentionally stay minimal here, as we want the default ignore file
-  // to be as meaningful for graphql-santa users as possible.
+  // to be as meaningful for nexus-future users as possible.
   await fs.write(
     '.gitignore',
     stripIndent`
@@ -207,17 +207,17 @@ export async function runBootstrapper(
   // If the user setup a db driver but not the connection URI yet, then do not
   // enter dev mode yet. Dev mode will result in a runtime-crashing app.
   if (!(askDatabase.database && !askDatabase.connectionURI)) {
-    // We will enter dev mode with the local version of graphql-santa. This is a kind
+    // We will enter dev mode with the local version of nexus-future. This is a kind
     // of cheat, but what we want users to have as their mental model. When they
     // terminate this dev session, they will restart it typically with e.g. `$
-    // yarn dev`. This global-graphql-santa-process-wrapping-local-graphql-santa-process
+    // yarn dev`. This global-nexus-future-process-wrapping-local-nexus-future-process
     // is unique to bootstrapping situations.
     logger.info('Entering dev mode ...')
 
     await layout.packageManager
       .runScript('dev', {
         stdio: 'inherit',
-        envAdditions: { GRAPHQL_SANTA_CREATE_HANDOFF: 'true' },
+        envAdditions: { NEXUS_FUTURE_CREATE_HANDOFF: 'true' },
         require: true,
       })
       .catch(error => {
@@ -330,14 +330,14 @@ async function askForPackageManager(): Promise<
 }
 
 /**
- * Check that the cwd is a suitable place to start a new graphql-santa project.
+ * Check that the cwd is a suitable place to start a new nexus-future project.
  */
 async function assertIsCleanSlate() {
   const contents = await fs.listAsync()
 
   if (contents !== undefined && contents.length > 0) {
     proc.fatal(
-      'Cannot create a new graphql-santa project here because the directory is not empty:\n %s',
+      'Cannot create a new nexus-future project here because the directory is not empty:\n %s',
       contents
     )
   }
@@ -347,7 +347,7 @@ async function helloWorldTemplate(layout: Layout.Layout) {
   await fs.writeAsync(
     layout.sourcePath('schema.ts'),
     stripIndent`
-    import { app } from "graphql-santa";
+    import { app } from "nexus-future";
 
     app.addToContext(req => {
       return {
@@ -399,7 +399,7 @@ async function helloWorldTemplate(layout: Layout.Layout) {
 }
 
 /**
- * Scaffold a new graphql-santa project from scratch
+ * Scaffold a new nexus-future project from scratch
  */
 async function scaffoldBaseFiles(layout: Layout.Layout, options: Options) {
   // TODO Template selector?
@@ -411,12 +411,12 @@ async function scaffoldBaseFiles(layout: Layout.Layout, options: Options) {
       name: options.projectName,
       license: 'UNLICENSED',
       dependencies: {
-        'graphql-santa': options.graphqlSantaVersion,
+        'nexus-future': options.nexusFutureVersion,
       },
       scripts: {
         format: "npx prettier --write './**/*.{ts,md}' '!./prisma/**/*.md'",
-        dev: 'santa dev',
-        build: 'santa build',
+        dev: 'nexus-future dev',
+        build: 'nexus-future build',
         start: 'node node_modules/.build',
       },
       prettier: {
@@ -443,9 +443,9 @@ async function scaffoldBaseFiles(layout: Layout.Layout, options: Options) {
             {
               "type": "node",
               "request": "launch",
-              "name": "Debug graphql-santa App",
+              "name": "Debug nexus-future App",
               "protocol": "inspector",
-              "runtimeExecutable": "\${workspaceRoot}/node_modules/.bin/graphql-santa",
+              "runtimeExecutable": "\${workspaceRoot}/node_modules/.bin/nexus-future",
               "runtimeArgs": ["dev"],
               "args": ["${layout.projectRelative(appEntrypointPath)}"],
               "sourceMaps": true,
@@ -458,7 +458,7 @@ async function scaffoldBaseFiles(layout: Layout.Layout, options: Options) {
   ])
 }
 
-const ENV_PARENT_DATA = 'GRAPHQL_SANTA_CREATE_DATA'
+const ENV_PARENT_DATA = 'NEXUS_FUTURE_CREATE_DATA'
 
 type SerializableParentData = {
   layout: Layout.Layout['data']
@@ -473,7 +473,7 @@ type ParentData = Omit<SerializableParentData, 'layout'> & {
 async function loadDataFromParentProcess(): Promise<ParentData> {
   if (!process.env[ENV_PARENT_DATA]) {
     logger.warn(
-      'We could not retrieve neccessary data from graphql-santa. Falling back to SQLite database.'
+      'We could not retrieve neccessary data from nexus-future. Falling back to SQLite database.'
     )
 
     return {
@@ -500,19 +500,19 @@ function saveDataForChildProcess(data: SerializableParentData): void {
 /**
  * Helper function for fetching the correct veresion of prisma plugin to
  * install. Useful for development where we can override the version installed
- * by environment variable GRAPHQL_SANTA_PLUGIN_PRISMA_VERSION.
+ * by environment variable NEXUS_FUTURE_PLUGIN_PRISMA_VERSION.
  */
 function getPrismaPluginVersion(): string {
   let prismaPluginVersion: string
-  if (process.env.GRAPHQL_SANTA_PLUGIN_PRISMA_VERSION) {
+  if (process.env.NEXUS_FUTURE_PLUGIN_PRISMA_VERSION) {
     logger.warn(
-      'found GRAPHQL_SANTA_PLUGIN_PRISMA_VERSION defined. This is only expected if you are actively developing on graphql-santa right now',
+      'found NEXUS_FUTURE_PLUGIN_PRISMA_VERSION defined. This is only expected if you are actively developing on nexus-future right now',
       {
-        GRAPHQL_SANTA_PLUGIN_PRISMA_VERSION:
-          process.env.GRAPHQL_SANTA_PLUGIN_PRISMA_VERSION,
+        NEXUS_FUTURE_PLUGIN_PRISMA_VERSION:
+          process.env.NEXUS_FUTURE_PLUGIN_PRISMA_VERSION,
       }
     )
-    prismaPluginVersion = process.env.GRAPHQL_SANTA_PLUGIN_PRISMA_VERSION
+    prismaPluginVersion = process.env.NEXUS_FUTURE_PLUGIN_PRISMA_VERSION
   } else {
     prismaPluginVersion = 'latest'
   }

--- a/src/cli/commands/create/plugin.ts
+++ b/src/cli/commands/create/plugin.ts
@@ -1,23 +1,23 @@
 /**
- * CLI command to help accelerate building a graphql-santa plugin. The scaffolding is
+ * CLI command to help accelerate building a nexus-future plugin. The scaffolding is
  * based on the result that `$ tsdx init` produces.
  */
 import { stripIndent } from 'common-tags'
 import * as fs from 'fs-jetpack'
 import prompts from 'prompts'
-import { pog, createGitRepository } from '../../../utils'
+import { Command } from '../../../lib/cli'
+import { createGitRepository, pog } from '../../../utils'
 import { logger } from '../../../utils/logger'
 import * as proc from '../../../utils/process'
-import { Command } from '../../../lib/cli'
 
 const log = pog.sub('cli:create:plugin')
 
 export default class Plugin implements Command {
   async parse() {
-    logger.info('Scaffolding a graphql-santa plugin')
+    logger.info('Scaffolding a nexus-future plugin')
 
     const pluginName = await askUserPluginName()
-    const pluginPackageName = 'graphql-santa-plugin-' + pluginName
+    const pluginPackageName = 'nexus-plugin-' + pluginName
     logger.info(`Creating directory ${pluginPackageName}...`)
     const projectPath = fs.path(pluginPackageName)
     await fs.dirAsync(projectPath)
@@ -86,7 +86,7 @@ export default class Plugin implements Command {
           prepack: 'yarn -s build',
         },
         peerDependencies: {
-          'graphql-santa': 'master',
+          'nexus-future': 'master',
         },
         husky: {
           hooks: {
@@ -143,16 +143,16 @@ export default class Plugin implements Command {
       fs.writeAsync(
         'src/index.ts',
         stripIndent`
-          import * as SantaPlugin from 'graphql-santa/plugin'
+          import * as NexusFuturePlugin from 'nexus-future/plugin'
 
-          export const create = SantaPlugin.create(santa => {
-            santa.workflow((hooks, _context) => {
+          export const create = NexusFuturePlugin.create(nexusFuture => {
+            nexusFuture.workflow((hooks, _context) => {
               hooks.build.onStart = async () => {
-                santa.utils.log.info('Hello from ${pluginName}!')
+                nexusFuture.utils.log.info('Hello from ${pluginName}!')
               }
             })
 
-            santa.runtime(() => {
+            nexusFuture.runtime(() => {
               return {
                 context: {
                   create: _req => {
@@ -182,7 +182,7 @@ export default class Plugin implements Command {
           '@babel/plugin-proposal-optional-chaining',
           '@types/jest',
           'husky',
-          'graphql-santa@master',
+          'nexus-future@master',
           'tsdx',
           'tslib',
           'typescript',
@@ -205,9 +205,9 @@ export default class Plugin implements Command {
  * Promp the user to give the plugin they are about to work on a name.
  */
 async function askUserPluginName(): Promise<string> {
-  // TODO prompt with "graphql-santa-plugin-" text faded gray e.g.
+  // TODO prompt with "nexus-plugin-" text faded gray e.g.
   //
-  // > graphql-santa-plugin-|
+  // > nexus-plugin-|
   //
   //
   // TODO check the npm registry to see if the name is already taken before
@@ -218,9 +218,6 @@ async function askUserPluginName(): Promise<string> {
     name: 'pluginName',
     message: 'What is the name of your plugin?',
   })
-  const pluginNameNormalized = pluginName.replace(
-    /^graphql-santa-plugin-(.+)/,
-    '$1'
-  )
+  const pluginNameNormalized = pluginName.replace(/^nexus-plugin-(.+)/, '$1')
   return pluginNameNormalized
 }

--- a/src/cli/commands/db/migrate/__default.ts
+++ b/src/cli/commands/db/migrate/__default.ts
@@ -1,8 +1,8 @@
-import { generateHelpForCommandIndex, Command } from '../../../../lib/cli'
+import { Command, generateHelpForCommandIndex } from '../../../../lib/cli'
 
 export class DbDefault implements Command {
   async parse(argv: string[]) {
-    // TODO: ! Unknown command "--help" when running graphql-santa db migrate --help
+    // TODO: ! Unknown command "--help" when running nexus-future db migrate --help
     return this.help()
   }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -3,10 +3,10 @@ import { stripIndent } from 'common-tags'
 import * as dotenv from 'dotenv'
 import { isError } from 'util'
 import * as Layout from '../framework/layout'
+import { CLI, HelpError } from '../lib/cli'
 import { fatal, isProcessFromProjectBin } from '../utils'
 import * as PackageManager from '../utils/package-manager'
 import * as Commands from './commands'
-import { HelpError, CLI } from '../lib/cli'
 
 // Loads env variable from .env file
 dotenv.config()
@@ -24,9 +24,9 @@ main().then(exitCode => {
 })
 
 /**
- * Check that this graphql-santa process is being run from a locally installed
+ * Check that this nexus-future process is being run from a locally installed
  * veresion unless there is local project or the local project does not have
- * graphql-santa installed.
+ * nexus-future installed.
  */
 async function guardNotGlobalCLIWithLocalProject(
   packageManager: PackageManager.PackageManager
@@ -34,21 +34,21 @@ async function guardNotGlobalCLIWithLocalProject(
   // TODO data is attainable from layout scan calculated later on... not optimal to call this twice...
   const projectType = await Layout.scanProjectType()
   if (
-    projectType.type === 'graphql_santa_project' &&
+    projectType.type === 'NEXUS_FUTURE_project' &&
     isProcessFromProjectBin(projectType.packageJsonPath)
   ) {
     // TODO make npm aware
     fatal(stripIndent`
-        You are using the graphql-santa cli from a location other than this project.
+        You are using the nexus-future cli from a location other than this project.
 
-        Location of the graphql-santa CLI you executed:      ${process.argv[1]}
-        Location of the graphql-santa CLI for this project:  ${projectType.packageJsonPath +
-          '/node_modules/.bin/graphql-santa'}
+        Location of the nexus-future CLI you executed:      ${process.argv[1]}
+        Location of the nexus-future CLI for this project:  ${projectType.packageJsonPath +
+          '/node_modules/.bin/nexus-future'}
         
-        Please use the graphql-santa CLI for this project:
+        Please use the nexus-future CLI for this project:
 
             ${packageManager.renderRunBin(
-              'graphql-santa ' + process.argv.slice(2).join(' ')
+              'nexus-future ' + process.argv.slice(2).join(' ')
             )}
       `)
   }

--- a/src/core/plugin/index.ts
+++ b/src/core/plugin/index.ts
@@ -1,23 +1,18 @@
 import { stripIndent } from 'common-tags'
 import * as fs from 'fs-jetpack'
-import prompts from 'prompts'
-import { fatal, pog, run, runSync } from '../../utils'
-import * as PackageManager from '../../utils/package-manager'
-import * as Chokidar from '../../watcher/chokidar'
+import * as Path from 'path'
+import prompts, * as Prompts from 'prompts'
 import * as Layout from '../../framework/layout'
 import { NexusConfig } from '../../framework/nexus'
 import { TestContext } from '../../framework/testing'
 import * as Logger from '../../lib/logger'
-import * as Path from 'path'
+import { CallbackRegistrer, MaybePromise, SideEffector } from '../../lib/utils'
+import { fatal, pog, run, runSync } from '../../utils'
+import * as PackageManager from '../../utils/package-manager'
+import * as Chokidar from '../../watcher/chokidar'
 
 const pluginSystemLogger = Logger.create({ name: 'plugin' })
 
-// We want to expose the prompts type in the plugin interface but, because we are
-// importing prompts with esModuleInterop, it would mean forcing the consumer to
-// also turn on esModuleInterop, which we do not want.
-//
-import * as Prompts from 'prompts'
-import { SideEffector, MaybePromise, CallbackRegistrer } from '../../lib/utils'
 type PromptsConstructor = <T extends string = string>(
   questions: Prompts.PromptObject<T> | Array<Prompts.PromptObject<T>>,
   options?: Prompts.Options
@@ -278,7 +273,7 @@ export function create(definer: Definer): DriverCreator {
 // }
 
 /**
- * Load all graphql-santa plugins installed into the project
+ * Load all nexus-future plugins installed into the project
  */
 export async function loadAllFromPackageJson(): Promise<Driver[]> {
   const packageJson: undefined | Record<string, any> = await fs.readAsync(
@@ -289,7 +284,7 @@ export async function loadAllFromPackageJson(): Promise<Driver[]> {
 }
 
 /**
- * Load all graphql-santa plugins installed into the project
+ * Load all nexus-future plugins installed into the project
  */
 export function loadAllFromPackageJsonSync(): Driver[] {
   const packageJson: undefined | Record<string, any> = fs.read(
@@ -313,7 +308,7 @@ function __doLoadAllFromPackageJson(
   if (depNames.length === 0) return []
 
   const pluginDepNames = depNames.filter(depName =>
-    depName.match(/^graphql-santa-plugin-.+/)
+    depName.match(/^nexus-plugin-.+/)
   )
   if (pluginDepNames.length === 0) return []
 
@@ -376,10 +371,10 @@ function __doLoadAllFromPackageJson(
 }
 
 /**
- * Parse a graphql-santa plugin package name to just the plugin name.
+ * Parse a nexus-future plugin package name to just the plugin name.
  */
 export function parsePluginName(packageName: string): null | string {
-  const matchResult = packageName.match(/^graphql-santa-plugin-(.+)/)
+  const matchResult = packageName.match(/^nexus-plugin-(.+)/)
 
   if (matchResult === null) return null
 

--- a/src/framework/app.ts
+++ b/src/framework/app.ts
@@ -1,15 +1,15 @@
 import { stripIndent, stripIndents } from 'common-tags'
 import * as fs from 'fs-jetpack'
+import * as HTTP from 'http'
+import * as Lo from 'lodash'
 import * as nexus from 'nexus'
 import { typegenAutoConfig } from 'nexus/dist/core'
+import * as Plugin from '../core/plugin'
 import * as Logger from '../lib/logger'
 import { pog, requireSchemaModules } from '../utils'
 import { createNexusConfig, createNexusSingleton } from './nexus'
-import * as Plugin from '../core/plugin'
-import * as singletonChecks from './singleton-checks'
-import * as HTTP from 'http'
-import * as Lo from 'lodash'
 import * as Server from './server'
+import * as singletonChecks from './singleton-checks'
 
 const log = pog.sub(__filename)
 const logger = Logger.create({ name: 'app' })
@@ -132,7 +132,7 @@ export function createApp(appConfig?: { types?: any }): App {
     extendInputType,
     server: {
       /**
-       * Start the server. If you do not call this explicitly then graphql-santa will
+       * Start the server. If you do not call this explicitly then nexus-future will
        * for you. You should not normally need to call this function yourself.
        */
       async start(opts: ServerOptions = {}): Promise<void> {
@@ -152,7 +152,7 @@ export function createApp(appConfig?: { types?: any }): App {
         // During dev mode we will dynamically require the user's schema modules.
         // At build time we inline static imports.
         // This code MUST run after user/system has had chance to run global installation
-        if (process.env.GRAPHQL_SANTA_STAGE === 'dev') {
+        if (process.env.NEXUS_FUTURE_STAGE === 'dev') {
           requireSchemaModules()
         }
 
@@ -203,8 +203,8 @@ export function createApp(appConfig?: { types?: any }): App {
 
           // Integrate user's app calls to app.addToContext
           const addToContextCallResults: string[] = process.env
-            .GRAPHQL_SANTA_TYPEGEN_ADD_CONTEXT_RESULTS
-            ? JSON.parse(process.env.GRAPHQL_SANTA_TYPEGEN_ADD_CONTEXT_RESULTS)
+            .NEXUS_FUTURE_TYPEGEN_ADD_CONTEXT_RESULTS
+            ? JSON.parse(process.env.NEXUS_FUTURE_TYPEGEN_ADD_CONTEXT_RESULTS)
             : []
 
           const addToContextInterfaces = addToContextCallResults
@@ -235,7 +235,7 @@ export function createApp(appConfig?: { types?: any }): App {
           }
 
           config.imports.push(
-            "import * as Logger from 'graphql-santa/dist/lib/logger'",
+            "import * as Logger from 'nexus-future/dist/lib/logger'",
             contextTypeContribSpecToCode({
               logger: 'Logger.Logger',
             })
@@ -305,15 +305,15 @@ const installGlobally = (app: App): App => {
     stringArg,
   })
 
-  const graphqlSantaTypeGenPath =
-    'node_modules/@types/typegen-graphql-santa/index.d.ts'
-  log('generating app global singleton typegen to %s', graphqlSantaTypeGenPath)
+  const nexusFutureTypeGenPath =
+    'node_modules/@types/typegen-nexus-future/index.d.ts'
+  log('generating app global singleton typegen to %s', nexusFutureTypeGenPath)
 
   fs.write(
-    graphqlSantaTypeGenPath,
+    nexusFutureTypeGenPath,
     stripIndent`
       import * as nexus from 'nexus'
-      import * as GQLSanta from 'graphql-santa'
+      import * as NexusFuture from 'nexus-future'
 
       type QueryType = typeof nexus.core.queryType
       type MutationType = typeof nexus.core.mutationType
@@ -326,7 +326,7 @@ const installGlobally = (app: App): App => {
       type StringArg = typeof nexus.stringArg
       
       declare global {
-        var app: GQLSanta.App
+        var app: NexusFuture.App
         var queryType: QueryType
         var mutationType: MutationType
         var objectType: ObjectType
@@ -337,11 +337,11 @@ const installGlobally = (app: App): App => {
         var intArg: IntArg
         var stringArg: StringArg
 
-        interface GQLSantaSingletonApp extends GQLSanta.App {}
+        interface NexusFutureSingletonApp extends NexusFuture.App {}
       
         namespace NodeJS {
           interface Global {
-            app: GQLSanta.App
+            app: NexusFuture.App
             queryType: QueryType
             mutationType: MutationType
             objectType: ObjectType
@@ -362,5 +362,5 @@ const installGlobally = (app: App): App => {
 
 export const isGlobalSingletonEnabled = (): boolean => {
   const packageJson = fs.read('package.json', 'json')
-  return packageJson?.['graphql-santa']?.singleton !== false
+  return packageJson?.['nexus-future']?.singleton !== false
 }

--- a/src/framework/config.ts
+++ b/src/framework/config.ts
@@ -31,11 +31,11 @@ type EnvironmentWithSecretLoader =
   | undefined
 
 interface Environment {
-  GRAPHQL_SANTA_DATABASE_URL?: string
+  NEXUS_FUTURE_DATABASE_URL?: string
   [env_key: string]: string | undefined
 }
 
-export const DATABASE_URL_ENV_NAME = 'GRAPHQL_SANTA_DATABASE_URL'
+export const DATABASE_URL_ENV_NAME = 'NEXUS_FUTURE_DATABASE_URL'
 
 function tryReadConfig(configPath: string): object | null {
   const { unregister } = registerTsExt()
@@ -46,7 +46,7 @@ function tryReadConfig(configPath: string): object | null {
     return config
   } catch (e) {
     log(
-      'we could not load graphql-santa config file at %s. reason: %O',
+      'we could not load nexus-future config file at %s. reason: %O',
       configPath,
       e
     )
@@ -62,7 +62,7 @@ function validateConfig(config: any): Config | null {
 
   if (!config.default) {
     fatal(
-      'Your config in `graphql-santa.config.ts` needs to be default exported. `export default createConfig({ ... })`'
+      'Your config in `nexus-future.config.ts` needs to be default exported. `export default createConfig({ ... })`'
     )
   }
 
@@ -70,7 +70,7 @@ function validateConfig(config: any): Config | null {
 }
 
 export function readConfig(): Config | null {
-  const config = tryReadConfig(fs.path('graphql-santa.config.ts'))
+  const config = tryReadConfig(fs.path('nexus-future.config.ts'))
   const validatedConfig = validateConfig(config)
 
   if (!validateConfig(config)) {
@@ -398,14 +398,14 @@ export function loadEnvironmentFromConfig(
 }
 
 /**
- * Helper method to configure graphql-santa. **Must be default exported in a `graphql-santa.config.ts` file**
+ * Helper method to configure nexus-future. **Must be default exported in a `nexus-future.config.ts` file**
  *
  * @example
  *
  * export default createConfig({
  *   environments: {
  *     development: {
- *       GRAPHQL_SANTA_DATABASE_URL: "<database_connection_url>"
+ *       NEXUS_FUTURE_DATABASE_URL: "<database_connection_url>"
  *     }
  *   }
  * })

--- a/src/framework/dev-mode.ts
+++ b/src/framework/dev-mode.ts
@@ -15,7 +15,7 @@ import { fatal } from '../utils/process'
 /**
  * Data
  */
-const DEV_MODE_ENV_VAR_NAME = 'GRAPHQL_SANTA_DEV_MODE'
+const DEV_MODE_ENV_VAR_NAME = 'NEXUS_FUTURE_DEV_MODE'
 
 /**
  * Eager integrity check.
@@ -62,7 +62,7 @@ function parseIsDevMode(): boolean {
 }
 /**
  * This function checks that dev mode and IPC are algined. IPC should only be
- * enabled when dev mode master is running graphql-santa app within its runner
+ * enabled when dev mode master is running nexus-future app within its runner
  * process. Dev mode being on or off is signified via a special environment
  * variable. If the environment variable is ever present but IPC not then this
  * means something is deeply wrong, and explicitly or subtlely not going to work.
@@ -72,7 +72,7 @@ function parseIsDevMode(): boolean {
  *      actually fork... ?
  *
  * We DO allow for IPC to be enabled while dev-mode is not, since we cannot
- * control all the cases where graphql-santa code might be forked and thus have IPC.
+ * control all the cases where nexus-future code might be forked and thus have IPC.
  * For example typegen which uses ts-node under the hood does a spawn, but
  * ts-node does a fork, and thus creates an IPC link.
  */

--- a/src/framework/layout.ts
+++ b/src/framework/layout.ts
@@ -216,14 +216,14 @@ function findPackageJsonPath(): string | null {
 }
 
 /**
- * Detect whether or not CWD is inside a graphql-santa project. graphql-santa project is
- * defined as there being a package.json in or above CWD with graphql-santa as a
+ * Detect whether or not CWD is inside a nexus-future project. nexus-future project is
+ * defined as there being a package.json in or above CWD with nexus-future as a
  * direct dependency.
  */
 export async function scanProjectType(): Promise<
   | { type: 'unknown' | 'new' }
   | {
-      type: 'graphql_santa_project' | 'node_project'
+      type: 'NEXUS_FUTURE_project' | 'node_project'
       packageJson: {}
       packageJsonPath: string
     }
@@ -238,8 +238,8 @@ export async function scanProjectType(): Promise<
   }
 
   const packageJson = fs.read(packageJsonPath, 'json')
-  if (packageJson?.dependencies?.['graphql-santa']) {
-    return { type: 'graphql_santa_project', packageJson, packageJsonPath }
+  if (packageJson?.dependencies?.['nexus-future']) {
+    return { type: 'NEXUS_FUTURE_project', packageJson, packageJsonPath }
   }
 
   return { type: 'node_project', packageJson, packageJsonPath }
@@ -254,11 +254,11 @@ async function isEmptyCWD(): Promise<boolean> {
   return contents === undefined || contents.length === 0
 }
 
-const ENV_VAR_DATA_NAME = 'GRAPHQL_SANTA_LAYOUT'
+const ENV_VAR_DATA_NAME = 'NEXUS_FUTURE_LAYOUT'
 
 export function saveDataForChildProcess(
   layout: Layout
-): { GRAPHQL_SANTA_LAYOUT: string } {
+): { NEXUS_FUTURE_LAYOUT: string } {
   return {
     [ENV_VAR_DATA_NAME]: JSON.stringify(layout.data),
   }

--- a/src/framework/nexus.ts
+++ b/src/framework/nexus.ts
@@ -1,13 +1,13 @@
-import * as nexus from 'nexus'
-import { generateSchema } from 'nexus/dist/core'
 import * as fs from 'fs-jetpack'
+import * as nexus from 'nexus'
 import * as Nexus from 'nexus'
+import { generateSchema } from 'nexus/dist/core'
 
 export function createNexusSingleton() {
   const __types: any[] = []
 
   /**
-   * Create the Nexus GraphQL Schema. If GRAPHQL_SANTA_SHOULD_AWAIT_TYPEGEN=true then the typegen
+   * Create the Nexus GraphQL Schema. If NEXUS_FUTURE_SHOULD_AWAIT_TYPEGEN=true then the typegen
    * disk write is awaited upon.
    */
   async function makeSchema(
@@ -15,15 +15,15 @@ export function createNexusSingleton() {
   ): Promise<nexus.core.NexusGraphQLSchema> {
     config.types.push(...__types)
 
-    // https://github.com/prisma-labs/graphql-santa/issues/33
-    const schema = await (process.env.GRAPHQL_SANTA_SHOULD_AWAIT_TYPEGEN ===
+    // https://github.com/graphql-nexus/nexus-future/issues/33
+    const schema = await (process.env.NEXUS_FUTURE_SHOULD_AWAIT_TYPEGEN ===
     'true'
       ? generateSchema(config)
       : Promise.resolve(nexus.makeSchema(config)))
 
     // HACK `generateSchema` in Nexus does not support this logic yet
     // TODO move this logic into Nexus
-    if (process.env.GRAPHQL_SANTA_SHOULD_EXIT_AFTER_GENERATE_ARTIFACTS) {
+    if (process.env.NEXUS_FUTURE_SHOULD_EXIT_AFTER_GENERATE_ARTIFACTS) {
       process.exit(0)
     }
 
@@ -138,13 +138,13 @@ export function createNexusConfig(): NexusConfig {
 }
 
 export const shouldGenerateArtifacts = (): boolean =>
-  process.env.GRAPHQL_SANTA_SHOULD_GENERATE_ARTIFACTS === 'true'
+  process.env.NEXUS_FUTURE_SHOULD_GENERATE_ARTIFACTS === 'true'
     ? true
-    : process.env.GRAPHQL_SANTA_SHOULD_GENERATE_ARTIFACTS === 'false'
+    : process.env.NEXUS_FUTURE_SHOULD_GENERATE_ARTIFACTS === 'false'
     ? false
     : Boolean(!process.env.NODE_ENV || process.env.NODE_ENV === 'development')
 
 export const shouldExitAfterGenerateArtifacts = (): boolean =>
-  process.env.GRAPHQL_SANTA_SHOULD_EXIT_AFTER_GENERATE_ARTIFACTS === 'true'
+  process.env.NEXUS_FUTURE_SHOULD_EXIT_AFTER_GENERATE_ARTIFACTS === 'true'
     ? true
     : false

--- a/src/framework/server.ts
+++ b/src/framework/server.ts
@@ -1,10 +1,10 @@
-import { sendServerReadySignalToDevModeMaster } from './dev-mode'
-import * as HTTP from 'http'
-import createExpressGraphql from 'express-graphql'
 import createExpress from 'express'
+import createExpressGraphql from 'express-graphql'
+import * as HTTP from 'http'
+import * as Net from 'net'
 import * as Plugin from '../core/plugin'
 import * as Logger from '../lib/logger'
-import * as Net from 'net'
+import { sendServerReadySignalToDevModeMaster } from './dev-mode'
 
 type Request = HTTP.IncomingMessage & { logger: Logger.Logger }
 type ContextContributor<T extends {}> = (req: Request) => T
@@ -17,8 +17,8 @@ const logger = Logger.create({ name: 'server' })
  */
 const optDefaults: Required<ExtraOptions> = {
   port:
-    typeof process.env.GRAPHQL_SANTA_PORT === 'string'
-      ? parseInt(process.env.GRAPHQL_SANTA_PORT, 10)
+    typeof process.env.NEXUS_FUTURE_PORT === 'string'
+      ? parseInt(process.env.NEXUS_FUTURE_PORT, 10)
       : typeof process.env.PORT === 'string'
       ? // e.g. Heroku convention https://stackoverflow.com/questions/28706180/setting-the-port-for-node-js-server-on-heroku
         parseInt(process.env.PORT, 10)

--- a/src/framework/start.ts
+++ b/src/framework/start.ts
@@ -29,21 +29,21 @@ export function createStartModuleContent(config: StartModuleConfig): string {
   if (config.internalStage === 'build') {
     output += stripIndent`
       // Guarantee that development mode features will not accidentally run
-      process.env.GRAPHQL_SANTA_SHOULD_GENERATE_ARTIFACTS = 'false'
+      process.env.NEXUS_FUTURE_SHOULD_GENERATE_ARTIFACTS = 'false'
 
     `
   } else if (config.internalStage === 'dev') {
     output += stripIndent`
       // Guarantee that development mode features are on
-      process.env.GRAPHQL_SANTA_SHOULD_GENERATE_ARTIFACTS = 'true'
-      process.env.GRAPHQL_SANTA_STAGE = 'dev'
+      process.env.NEXUS_FUTURE_SHOULD_GENERATE_ARTIFACTS = 'true'
+      process.env.NEXUS_FUTURE_STAGE = 'dev'
     `
   }
 
   output += '\n\n\n'
   output += stripIndent`
     // Guarantee the side-effect features like singleton global do run
-    require("graphql-santa")
+    require("nexus-future")
   `
 
   if (config.internalStage === 'build') {
@@ -52,14 +52,14 @@ export function createStartModuleContent(config: StartModuleConfig): string {
       output += '\n\n\n'
       output += stripIndent`
         // Import the user's schema modules
-        // This MUST come after graphql-santa package has been imported for its side-effects
+        // This MUST come after nexus-future package has been imported for its side-effects
         ${staticImports}
       `
     }
   }
 
   // TODO Despite the comment below there are still sometimes reasons to do so
-  // https://github.com/prisma-labs/graphql-santa/issues/141
+  // https://github.com/graphql-nexus/nexus-future/issues/141
   output += '\n\n\n'
   output += config.appPath
     ? stripIndent`
@@ -74,8 +74,8 @@ export function createStartModuleContent(config: StartModuleConfig): string {
         // Users should normally not boot the server manually as doing so does not
         // bring value to the user's codebase.
 
-        const { app } = require('graphql-santa')
-        const singletonChecks = require('graphql-santa/dist/framework/singleton-checks')
+        const { app } = require('nexus-future')
+        const singletonChecks = require('nexus-future/dist/framework/singleton-checks')
 
         if (singletonChecks.state.is_was_server_start_called === false) {
           app.server.start()
@@ -83,7 +83,7 @@ export function createStartModuleContent(config: StartModuleConfig): string {
         `
     : stripIndent`
         // Start the server
-        const { app } = require('graphql-santa')
+        const { app } = require('nexus-future')
         app.server.start()
       `
 

--- a/src/framework/testing.ts
+++ b/src/framework/testing.ts
@@ -1,9 +1,9 @@
 import getPort from 'get-port'
 import { GraphQLClient } from 'graphql-request'
 import * as Lo from 'lodash'
+import * as Plugin from '../core/plugin'
 import { app } from './index'
 import * as Layout from './layout'
-import * as Plugin from '../core/plugin'
 import * as singletonChecks from './singleton-checks'
 
 type AppClient = {
@@ -21,7 +21,7 @@ export function createAppClient(apiUrl: string): AppClient {
 }
 
 declare global {
-  interface GraphQLSantaTestContextApp {
+  interface nexusFutureTestContextApp {
     query: AppClient['query']
     server: {
       start: () => Promise<void>
@@ -29,12 +29,12 @@ declare global {
     }
   }
 
-  interface GraphQLSantaTestContextRoot {
-    app: GraphQLSantaTestContextApp
+  interface nexusFutureTestContextRoot {
+    app: nexusFutureTestContextApp
   }
 }
 
-export type TestContext = GraphQLSantaTestContextRoot
+export type TestContext = nexusFutureTestContextRoot
 
 /**
  * Setup a test context providing utilities to query against your GraphQL API
@@ -43,7 +43,7 @@ export type TestContext = GraphQLSantaTestContextRoot
  *
  * With jest
  * ```
- * import { setupTest, TestContext } from 'graphql-santa/testing'
+ * import { setupTest, TestContext } from 'nexus-future/testing'
  *
  * let testCtx: TestContext
  *
@@ -59,7 +59,7 @@ export type TestContext = GraphQLSantaTestContextRoot
  */
 export async function createTestContext(): Promise<TestContext> {
   // Guarantee that development mode features are on
-  process.env.GRAPHQL_SANTA_STAGE = 'dev'
+  process.env.NEXUS_FUTURE_STAGE = 'dev'
 
   const port = await getPort({ port: getPort.makeRange(4000, 6000) })
   const apiUrl = `http://localhost:${port}/graphql`

--- a/src/lib/cli/cli.ts
+++ b/src/lib/cli/cli.ts
@@ -207,15 +207,15 @@ export class CLI implements Command {
   // TODO generate this from cli tree
   // static help template
   private static help = format(`
-    graphql-santa - GraphQL APIs without the hassle
+    nexus-future - GraphQL APIs without the hassle
 
     ${chalk.bold('Usage')}
 
-      ${chalk.dim(`$`)} graphql-santa [command]
+      ${chalk.dim(`$`)} nexus-future [command]
 
     ${chalk.bold('Commands')}
 
-        create   Setup a ready-to-use graphql-santa
+        create   Setup a ready-to-use nexus-future
            dev   Develop your application in watch mode
          build   Build a production-ready server
       generate   Generate the artifacts
@@ -224,13 +224,13 @@ export class CLI implements Command {
 
     ${chalk.bold('Examples')}
 
-      Initialize files for a new graphql-santa project
-      ${chalk.dim(`$`)} graphql-santa create
+      Initialize files for a new nexus-future project
+      ${chalk.dim(`$`)} nexus-future create
 
       Start developing and watch your changes locally
-      ${chalk.dim(`$`)} graphql-santa dev
+      ${chalk.dim(`$`)} nexus-future dev
 
       Build a production-ready server
-      ${chalk.dim(`$`)} graphql-santa build
+      ${chalk.dim(`$`)} nexus-future build
   `)
 }

--- a/src/lib/cli/helpers.ts
+++ b/src/lib/cli/helpers.ts
@@ -41,7 +41,7 @@ export function generateHelpForCommandIndex(
   return `
 ${chalk.bold('Usage:')}
     
-${chalk.gray('$')} graphql-santa ${commandName} [${subCommands
+${chalk.gray('$')} nexus-future ${commandName} [${subCommands
     .map(c => c.name)
     .join('|')}]
 
@@ -68,7 +68,7 @@ ${description}
 
 ${chalk.bold('Usage:')}
     
-${chalk.gray('$')} graphql-santa ${commandName} [options]
+${chalk.gray('$')} nexus-future ${commandName} [options]
 
 ${chalk.bold('Options:')}
 

--- a/src/lib/logger/pino.ts
+++ b/src/lib/logger/pino.ts
@@ -8,7 +8,7 @@ export { Logger } from 'pino'
 /**
  * The pino typings are poor and, for example, do not account for prettifier or
  * mixin field. Also see note from Matteo about not using them:
- * https://github.com/prisma-labs/graphql-santa/pull/244#issuecomment-572573672
+ * https://github.com/graphql-nexus/nexus-future/pull/244#issuecomment-572573672
  */
 type ActualPinoOptions = Pino.LoggerOptions & {
   prettifier: (opts: any) => (logRec: any) => string

--- a/src/utils/artifact-generation.ts
+++ b/src/utils/artifact-generation.ts
@@ -9,10 +9,10 @@ export async function generateArtifacts(startScript: string): Promise<void> {
     encoding: 'utf8',
     env: {
       ...process.env,
-      GRAPHQL_SANTA_STAGE: 'dev',
-      GRAPHQL_SANTA_SHOULD_AWAIT_TYPEGEN: 'true',
-      GRAPHQL_SANTA_SHOULD_GENERATE_ARTIFACTS: 'true',
-      GRAPHQL_SANTA_SHOULD_EXIT_AFTER_GENERATE_ARTIFACTS: 'true',
+      NEXUS_FUTURE_STAGE: 'dev',
+      NEXUS_FUTURE_SHOULD_AWAIT_TYPEGEN: 'true',
+      NEXUS_FUTURE_SHOULD_GENERATE_ARTIFACTS: 'true',
+      NEXUS_FUTURE_SHOULD_EXIT_AFTER_GENERATE_ARTIFACTS: 'true',
       TS_NODE_TRANSPILE_ONLY: 'true',
     },
   })

--- a/src/utils/db-driver.ts
+++ b/src/utils/db-driver.ts
@@ -1,6 +1,6 @@
 import { stripIndent } from 'common-tags'
-import * as Layout from '../framework/layout'
 import * as Plugin from '../core/plugin'
+import * as Layout from '../framework/layout'
 import { fatal } from './process'
 
 export async function validateAndLoadDBDriver(): Promise<Plugin.WorkflowHooks> {
@@ -11,7 +11,7 @@ export async function validateAndLoadDBDriver(): Promise<Plugin.WorkflowHooks> {
   if (dbDrivers.length === 0) {
     fatal(
       stripIndent`
-        You have no database driver installed. Official drivers: "graphql-santa-plugin-prisma".
+        You have no database driver installed. Official drivers: "nexus-plugin-prisma".
         Run ${layout.packageManager.renderAddDeps([
           '<db-driver>',
         ])} to install one.

--- a/src/utils/deploy-target.ts
+++ b/src/utils/deploy-target.ts
@@ -38,7 +38,7 @@ export function normalizeTarget(
 
   if (!SUPPORTED_DEPLOY_TARGETS.includes(deployTarget as any)) {
     fatal(
-      `--deployment \`${deployTarget}\` is not supported by graphql-santa. Supported deployment targets: ${formattedSupportedDeployTargets}}`
+      `--deployment \`${deployTarget}\` is not supported by nexus-future. Supported deployment targets: ${formattedSupportedDeployTargets}}`
     )
   }
 
@@ -211,19 +211,19 @@ function validateHeroku(layout: Layout): ValidatorResult {
     if (!packageJsonContent.scripts?.build) {
       logger.error('A `build` script is needed in your `package.json` file.')
       logger.error(
-        `Please add the following to your \`package.json\` file: "scripts": { "build": "graphql-santa build -d heroku" }`
+        `Please add the following to your \`package.json\` file: "scripts": { "build": "nexus-future build -d heroku" }`
       )
       console.log()
       isValid = false
     }
 
-    // Make sure the build script is using graphql-santa build
+    // Make sure the build script is using nexus-future build
     if (
       packageJsonContent.scripts?.build &&
-      !packageJsonContent.scripts.build.includes('graphql-santa build')
+      !packageJsonContent.scripts.build.includes('nexus-future build')
     ) {
       logger.error(
-        'Please make sure your `build` script in your `package.json` file runs the command `graphql-santa build -d heroku`'
+        'Please make sure your `build` script in your `package.json` file runs the command `nexus-future build -d heroku`'
       )
       console.log()
       isValid = false
@@ -256,7 +256,7 @@ function validateHeroku(layout: Layout): ValidatorResult {
 }
 
 const TARGET_TO_POST_BUILD_MESSAGE: Record<SupportedTargets, string> = {
-  now: `Please run \`now\` to deploy your graphql-santa server. Your endpoint will be available at http://<id>.now.sh/graphql`,
+  now: `Please run \`now\` to deploy your nexus-future server. Your endpoint will be available at http://<id>.now.sh/graphql`,
   heroku: `\
 Please run the following commands to deploy to heroku:
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,6 @@
 import * as Logger from '../lib/logger'
 
-export const logger = Logger.create({ name: 'santa' })
+export const logger = Logger.create({ name: 'nexus-future' })
 
 // Convenience explicitly named export for modules that want to import and crate
 // child logger right away

--- a/src/utils/pog.ts
+++ b/src/utils/pog.ts
@@ -1,7 +1,7 @@
 import * as Debug from 'debug'
 import * as Path from 'path'
 
-const doLog = Debug.debug('graphql-santa')
+const doLog = Debug.debug('nexus-future')
 
 export function pog(
   formatter: unknown,
@@ -12,7 +12,7 @@ export function pog(
 
 export namespace pog {
   /**
-   * Create a debug logger prefixed with graphql-santa log namesapce.
+   * Create a debug logger prefixed with nexus-future log namesapce.
    * The given component name can be a path and the dir path and extension will
    * be automatically stripped. This allows the following pattern from the
    * caller side.
@@ -25,6 +25,6 @@ export namespace pog {
    */
   export const sub = (component: string) => {
     const parsed = Path.parse(component)
-    return Debug.debug(`graphql-santa:${parsed.name}`)
+    return Debug.debug(`nexus-future:${parsed.name}`)
   }
 }

--- a/src/utils/tsc.ts
+++ b/src/utils/tsc.ts
@@ -3,8 +3,8 @@ import * as fs from 'fs-jetpack'
 import * as path from 'path'
 import * as ts from 'typescript'
 import { Layout } from '../framework/layout'
-import { pog } from './pog'
 import { logger } from './logger'
+import { pog } from './pog'
 
 const log = pog.sub('compiler')
 
@@ -46,8 +46,8 @@ export function findConfigFile(fileName: string, opts: { required: boolean }) {
 }
 
 /**
- * Fetch the tsconfig file for graphql-santa, handling special post-processing for
- * graphql-santa projects etc.
+ * Fetch the tsconfig file for nexus-future, handling special post-processing for
+ * nexus-future projects etc.
  */
 export function readTsConfig(layout: Layout): ts.ParsedCommandLine {
   const tsConfigPath = findConfigFile('tsconfig.json', { required: true })
@@ -88,7 +88,7 @@ export function readTsConfig(layout: Layout): ts.ParsedCommandLine {
   )
 
   /**
-   * Force tsconfig settings in ways that align with graphql-santa projects.
+   * Force tsconfig settings in ways that align with nexus-future projects.
    */
 
   // Target ES5 output by default (instead of ES3).
@@ -122,7 +122,7 @@ export function createTSProgram(
     rootNames: tsConfig.fileNames,
     options: {
       incremental: true,
-      tsBuildInfoFile: './node_modules/.graphql-santa/cache.tsbuildinfo',
+      tsBuildInfoFile: './node_modules/.nexus-future/cache.tsbuildinfo',
       ...tsConfig.options,
     },
   })
@@ -289,19 +289,19 @@ export function createTSConfigContents(layout: Layout): string {
         "module": "commonjs",
         "lib": ["esnext"],
         "strict": true,
-        // [1] graphql-santa managed
+        // [1] nexus-future managed
         // "rootDir": "${layout.sourceRootRelative}",
         // "outDir": "${layout.buildOutput}",
       },
-      // [1] graphql-santa managed
+      // [1] nexus-future managed
       // "include": "${layout.sourceRootRelative}"
     }
 
-    // [1] graphql-santa managed
+    // [1] nexus-future managed
     //
-    // These settings are managed by graphql-santa.
+    // These settings are managed by nexus-future.
     // Do not edit these manually. Please refer to
-    // https://github.com/prisma-labs/graphql-santa/issues/82
+    // https://github.com/graphql-nexus/nexus-future/issues/82
     // Contribute feedback/use-cases if you feel strongly
     // about controlling these settings manually.
   `

--- a/src/watcher/runner.ts
+++ b/src/watcher/runner.ts
@@ -35,11 +35,11 @@ register({
     rootNames: tsConfig.fileNames,
     options: {
       incremental: true,
-      tsBuildInfoFile: './node_modules/.graphql-santa/cache.tsbuildinfo',
+      tsBuildInfoFile: './node_modules/.nexus-future/cache.tsbuildinfo',
       ...tsConfig.options,
     },
   })
-  process.env.GRAPHQL_SANTA_TYPEGEN_ADD_CONTEXT_RESULTS = JSON.stringify(
+  process.env.NEXUS_FUTURE_TYPEGEN_ADD_CONTEXT_RESULTS = JSON.stringify(
     extractContextTypes(program)
   )
   log('finished context type extraction')
@@ -48,7 +48,7 @@ register({
   process.argv.splice(1, 1)
 
   // A signal that the framework can use to make integrity checks with
-  process.env.GRAPHQL_SANTA_DEV_MODE = 'true'
+  process.env.NEXUS_FUTURE_DEV_MODE = 'true'
 
   if (process.env.DEBUG_RUNNER) {
     process.env.DEBUG = process.env.DEBUG_RUNNER
@@ -143,14 +143,14 @@ register({
     ipc.send({ required: file })
   })
 
-  if (!process.env.GRAPHQL_SANTA_EVAL) {
-    throw new Error('process.env.GRAPHQL_SANTA_EVAL is required')
+  if (!process.env.NEXUS_FUTURE_EVAL) {
+    throw new Error('process.env.NEXUS_FUTURE_EVAL is required')
   }
 
-  evalScript(process.env.GRAPHQL_SANTA_EVAL)
+  evalScript(process.env.NEXUS_FUTURE_EVAL)
 
   function evalScript(script: string) {
-    const EVAL_FILENAME = process.env.GRAPHQL_SANTA_EVAL_FILENAME!
+    const EVAL_FILENAME = process.env.NEXUS_FUTURE_EVAL_FILENAME!
     const module = new Module(EVAL_FILENAME)
     module.filename = EVAL_FILENAME
     module.paths = (Module as any)._nodeModulePaths(cwd)

--- a/src/watcher/watcher.ts
+++ b/src/watcher/watcher.ts
@@ -33,7 +33,7 @@ export function createWatcher(opts: Opts): Promise<void> {
 
     // TODO watch for changes to tsconfig and take correct action
     // TODO watch for changes to package json and take correct action (imagine
-    // there could be graphql-santa config in there)
+    // there could be nexus-future config in there)
     // TODO restart should take place following npm install/remove yarn
     // add/remove/install etc.
     // TODO need a way to test file matching given patterns. Hard to get right,
@@ -149,7 +149,7 @@ export function createWatcher(opts: Opts): Promise<void> {
       if (runner.exited) return Promise.resolve()
 
       // TODO maybe we should be a timeout here so that child process hanging
-      // will never prevent graphql-santa dev from exiting nicely.
+      // will never prevent nexus-future dev from exiting nicely.
       return sendSigterm(runner)
         .then(() => {
           log('sigterm to runner process tree completed')
@@ -285,15 +285,15 @@ function startRunner(
   // const child = fork('-r' [runnerModulePath, childHookPath], {
   //
   // We are leaving this as a future fix, refer to:
-  // https://github.com/prisma-labs/graphql-santa/issues/76
+  // https://github.com/graphql-nexus/nexus-future/issues/76
   const cmd = [...(opts.nodeArgs || []), runnerModulePath]
   const child = fork(cmd[0], cmd.slice(1), {
     cwd: process.cwd(),
     silent: true,
     env: {
       ...process.env,
-      GRAPHQL_SANTA_EVAL: opts.eval.code,
-      GRAPHQL_SANTA_EVAL_FILENAME: opts.eval.fileName,
+      NEXUS_FUTURE_EVAL: opts.eval.code,
+      NEXUS_FUTURE_EVAL_FILENAME: opts.eval.fileName,
       ...saveDataForChildProcess(opts.layout),
     },
   }) as Process

--- a/test/__helpers/workspace.ts
+++ b/test/__helpers/workspace.ts
@@ -1,11 +1,11 @@
 import * as jetpack from 'fs-jetpack'
 import * as path from 'path'
 import createGit, { SimpleGit } from 'simple-git/promise'
-import { gitRepo, gitReset } from './utils'
 import { createRunner } from '../../src/utils'
+import { gitRepo, gitReset } from './utils'
 
 type Workspace = {
-  dir: { path: string; pathRelativeToGraphqlSanta: string; cacheHit: boolean }
+  dir: { path: string; pathRelativeTonexusFuture: string; cacheHit: boolean }
   run: ReturnType<typeof createRunner>
   fs: ReturnType<typeof jetpack.dir>
   git: SimpleGit
@@ -27,7 +27,7 @@ export function createWorkspace(config: Options): Workspace {
     // In case of a cache hit where we manually debugged the directory or
     // somehow else it changed.
     await gitReset(ws.git)
-    // HACK without this the santa bin is missing because its a diff undone by the reset
+    // HACK without this the nexus-future bin is missing because its a diff undone by the reset
     ws.run('yarn --force', { require: true })
   })
 
@@ -55,9 +55,9 @@ async function doCreateWorkspace(config: Options): Promise<Workspace> {
   ).trim()
   const cacheKey = `v${ver}-yarnlock-${yarnLockHash}-gitbranch-${currentGitBranch}-testv${testVer}`
 
-  dir.path = `/tmp/graphql-santa-integration-test-project-bases/${config.name}-${cacheKey}`
+  dir.path = `/tmp/nexus-future-integration-test-project-bases/${config.name}-${cacheKey}`
 
-  dir.pathRelativeToGraphqlSanta =
+  dir.pathRelativeTonexusFuture =
     '../' + path.relative(dir.path, path.join(__dirname, '../..'))
 
   if ((await jetpack.existsAsync(dir.path)) !== false) {
@@ -85,11 +85,11 @@ async function doCreateWorkspace(config: Options): Promise<Workspace> {
         name: 'test-app',
         license: 'MIT',
         dependencies: {
-          'graphql-santa': dir.pathRelativeToGraphqlSanta,
+          'nexus-future': dir.pathRelativeTonexusFuture,
         },
         scripts: {
           postinstall:
-            'yarn -s link graphql-santa && chmod +x node_modules/.bin/graphql-santa',
+            'yarn -s link nexus-future && chmod +x node_modules/.bin/nexus-future',
         },
       }),
       fs.writeAsync(

--- a/test/integration/__snapshots__/build.spec.ts.snap
+++ b/test/integration/__snapshots__/build.spec.ts.snap
@@ -184,7 +184,7 @@ Object {
 
 exports[`exits 1 if app does not type check 1`] = `
 Object {
-  "command": "yarn -s santa build",
+  "command": "yarn -s nexus-future build",
   "exitCode": 1,
   "signal": null,
   "stderr": "Error: [96mapp.ts[0m:[93m1[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType '\\"bar\\"' is not assignable to type 'number'.
@@ -192,9 +192,9 @@ Object {
 [7m1[0m const foo: number =  \\"bar\\"
 [7m [0m [91m      ~~~[0m
 
-    at Object.compile (/Users/jasonkuhrt/projects/prisma-labs/graphql-santa/dist/utils/tsc.js:107:15)
-    at parse (/Users/jasonkuhrt/projects/prisma-labs/graphql-santa/dist/cli/commands/build.js:66:17)
-    at async main (/Users/jasonkuhrt/projects/prisma-labs/graphql-santa/dist/cli/index.js:77:20)
+    at Object.compile (/Users/jasonkuhrt/projects/graphql-nexus/nexus-future/dist/utils/tsc.js:107:15)
+    at parse (/Users/jasonkuhrt/projects/graphql-nexus/nexus-future/dist/cli/commands/build.js:66:17)
+    at async main (/Users/jasonkuhrt/projects/graphql-nexus/nexus-future/dist/cli/index.js:77:20)
 ",
   "stdout": "Generating Nexus artifacts ...
 Compiling ...
@@ -204,7 +204,7 @@ Compiling ...
 
 exports[`exits 1 if typegen errors out 1`] = `
 Object {
-  "command": "yarn -s santa build",
+  "command": "yarn -s nexus-future build",
   "exitCode": 1,
   "signal": null,
   "stderr": "Error: 
@@ -215,9 +215,9 @@ app.ts(1,14): error TS1134: Variable declaration expected.
 
 
     
-    at Object.generateArtifacts (/Users/jasonkuhrt/projects/prisma-labs/graphql-santa/dist/utils/artifact-generation.js:21:23)
-    at parse (/Users/jasonkuhrt/projects/prisma-labs/graphql-santa/dist/cli/commands/build.js:55:23)
-    at async main (/Users/jasonkuhrt/projects/prisma-labs/graphql-santa/dist/cli/index.js:77:20)
+    at Object.generateArtifacts (/Users/jasonkuhrt/projects/graphql-nexus/nexus-future/dist/utils/artifact-generation.js:21:23)
+    at parse (/Users/jasonkuhrt/projects/graphql-nexus/nexus-future/dist/cli/commands/build.js:55:23)
+    at async main (/Users/jasonkuhrt/projects/graphql-nexus/nexus-future/dist/cli/index.js:77:20)
 ",
   "stdout": "Generating Nexus artifacts ...
 ",

--- a/test/integration/build.spec.ts
+++ b/test/integration/build.spec.ts
@@ -1,7 +1,7 @@
 // TODO boot and query to take integration test confidence even further
 
-import { createWorkspace } from '../__helpers'
 import { DEFAULT_BUILD_FOLDER_NAME } from '../../src/framework/layout'
+import { createWorkspace } from '../__helpers'
 
 const ws = createWorkspace({
   name: 'build',
@@ -9,14 +9,14 @@ const ws = createWorkspace({
 
 it('exits 1 if typegen errors out', () => {
   ws.fs.write('app.ts', `const foo :: "bar"`)
-  const result = ws.run('yarn -s santa build')
+  const result = ws.run('yarn -s nexus-future build')
   delete result.error
   expect(result).toMatchSnapshot()
 })
 
 it('exits 1 if app does not type check', () => {
   ws.fs.write('app.ts', `const foo: number =  "bar"`)
-  const result = ws.run('yarn -s santa build')
+  const result = ws.run('yarn -s nexus-future build')
   delete result.error
   expect(result).toMatchSnapshot()
 })
@@ -25,7 +25,7 @@ it('can build with just a schema module', () => {
   ws.fs.write(
     'schema.ts',
     `
-      import { app } from 'graphql-santa'
+      import { app } from 'nexus-future'
 
       app.objectType({
         name: 'A',
@@ -36,7 +36,7 @@ it('can build with just a schema module', () => {
     `
   )
 
-  const result = ws.run('yarn -s graphql-santa build')
+  const result = ws.run('yarn -s nexus-future build')
   expect(result).toMatchSnapshot()
   expect(ws.fs.inspectTree(DEFAULT_BUILD_FOLDER_NAME)).toMatchSnapshot()
 })
@@ -45,7 +45,7 @@ it('can build with just a schema folder of modules', () => {
   ws.fs.write(
     'schema/a.ts',
     `
-      import { app } from 'graphql-santa'
+      import { app } from 'nexus-future'
 
       app.objectType({
         name: 'A',
@@ -56,7 +56,7 @@ it('can build with just a schema folder of modules', () => {
     `
   )
 
-  const result = ws.run('yarn -s graphql-santa build')
+  const result = ws.run('yarn -s nexus-future build')
   expect(result).toMatchSnapshot()
   expect(ws.fs.inspectTree(DEFAULT_BUILD_FOLDER_NAME)).toMatchSnapshot()
 })
@@ -65,7 +65,7 @@ it('can build with schema + app modules', () => {
   ws.fs.write(
     'schema.ts',
     `
-      import { app } from 'graphql-santa'
+      import { app } from 'nexus-future'
 
       app.objectType({
         name: 'A',
@@ -79,12 +79,12 @@ it('can build with schema + app modules', () => {
   ws.fs.write(
     'app.ts',
     `
-      import { app } from 'graphql-santa'
+      import { app } from 'nexus-future'
       app.server.start()
     `
   )
 
-  const result = ws.run('yarn -s graphql-santa build')
+  const result = ws.run('yarn -s nexus-future build')
   expect(result).toMatchSnapshot()
   expect(ws.fs.inspectTree(DEFAULT_BUILD_FOLDER_NAME)).toMatchSnapshot()
 })
@@ -93,7 +93,7 @@ it('can nest modules', () => {
   ws.fs.write(
     'graphql/schema.ts',
     `
-      import { app } from 'graphql-santa'
+      import { app } from 'nexus-future'
 
       app.objectType({
         name: 'A',
@@ -107,12 +107,12 @@ it('can nest modules', () => {
   ws.fs.write(
     'graphql/app.ts',
     `
-      import { app } from 'graphql-santa'
+      import { app } from 'nexus-future'
       app.server.start()
     `
   )
 
-  const result = ws.run('yarn -s graphql-santa build')
+  const result = ws.run('yarn -s nexus-future build')
   expect(result).toMatchSnapshot()
   expect(ws.fs.inspectTree(DEFAULT_BUILD_FOLDER_NAME)).toMatchSnapshot()
 })
@@ -121,7 +121,7 @@ it('can build a plugin', () => {
   ws.fs.write(
     'myplugin.ts',
     `	
-      import { Plugin } from 'graphql-santa'	
+      import { Plugin } from 'nexus-future'	
 
       export type Context = {	
         a: 1	
@@ -148,7 +148,7 @@ it('can build a plugin', () => {
   ws.fs.write(
     'schema.ts',
     `
-      import { app } from 'graphql-santa'
+      import { app } from 'nexus-future'
 
       app.queryType({	
         definition(t) {	
@@ -176,14 +176,14 @@ it('can build a plugin', () => {
   ws.fs.write(
     'app.ts',
     `	
-      import { app } from 'graphql-santa'
+      import { app } from 'nexus-future'
       import myplugin from './myplugin'	
 
       app.use(myplugin).server.start()	
     `
   )
 
-  const result = ws.run('yarn -s graphql-santa build')
+  const result = ws.run('yarn -s nexus-future build')
   expect(result).toMatchSnapshot()
   expect(ws.fs.inspectTree(DEFAULT_BUILD_FOLDER_NAME)).toMatchSnapshot()
 })

--- a/test/integration/doctor.spec.ts
+++ b/test/integration/doctor.spec.ts
@@ -7,7 +7,7 @@ const ws = createWorkspace({
 it('warns and scaffold if there is no tsconfig', () => {
   ws.fs.remove('tsconfig.json')
 
-  expect(ws.run('yarn -s graphql-santa doctor')).toMatchInlineSnapshot(`
+  expect(ws.run('yarn -s nexus-future doctor')).toMatchInlineSnapshot(`
     Object {
       "status": 0,
       "stderr": "",
@@ -23,12 +23,12 @@ it('errors if tsconfig is not in the project dir', () => {
   ws.fs.remove('tsconfig.json')
   ws.fs.write('../tsconfig.json', '')
 
-  expect(ws.run('yarn -s graphql-santa doctor', { require: false }))
+  expect(ws.run('yarn -s nexus-future doctor', { require: false }))
     .toMatchInlineSnapshot(`
     Object {
       "status": 0,
       "stderr": "[31mERROR:[39m Your tsconfig.json file needs to be in your project root directory
-    [31mERROR:[39m Found /private/tmp/graphql-santa-integration-test-project-bases/tsconfig.json, expected /private/tmp/graphql-santa-integration-test-project-bases/doctor-v5-yarnlock-201221dbef7978122d753bdd99660770-gitbranch-master-testv1/tsconfig.json
+    [31mERROR:[39m Found /private/tmp/nexus-future-integration-test-project-bases/tsconfig.json, expected /private/tmp/nexus-future-integration-test-project-bases/doctor-v5-yarnlock-201221dbef7978122d753bdd99660770-gitbranch-master-testv1/tsconfig.json
     ",
       "stdout": "[1m-- tsconfig.json --[22m
     ",
@@ -39,9 +39,9 @@ it('errors if tsconfig is not in the project dir', () => {
 })
 
 it('validates that there is a tsconfig.json file', () => {
-  ws.fs.write('.gitignore', '.graphql-santa')
+  ws.fs.write('.gitignore', '.nexus-future')
 
-  expect(ws.run('yarn -s graphql-santa doctor')).toMatchInlineSnapshot(`
+  expect(ws.run('yarn -s nexus-future doctor')).toMatchInlineSnapshot(`
     Object {
       "status": 0,
       "stderr": "",

--- a/test/integration/prisma/build.spec.ts
+++ b/test/integration/prisma/build.spec.ts
@@ -1,5 +1,5 @@
-import { createWorkspace } from '../../__helpers'
 import { DEFAULT_BUILD_FOLDER_NAME } from '../../../src/framework/layout'
+import { createWorkspace } from '../../__helpers'
 
 const ws = createWorkspace({
   name: 'prisma-build',
@@ -26,7 +26,7 @@ it('can build a prisma framework project', () => {
   ws.fs.write(
     'schema.ts',
     `
-      import { app } from 'graphql-santa'
+      import { app } from 'nexus-future'
 
       app.objectType({
         name: 'User',
@@ -38,7 +38,7 @@ it('can build a prisma framework project', () => {
     `
   )
 
-  const result = ws.run('yarn -s graphql-santa build')
+  const result = ws.run('yarn -s nexus-future build')
   expect(result).toMatchSnapshot()
   expect(ws.fs.inspectTree(DEFAULT_BUILD_FOLDER_NAME)).toMatchSnapshot()
 })


### PR DESCRIPTION
BREAKING CHANGE:

- how the package is installed

   before:

   ```
   npm install graphql-santa
   ```

   now:

   ```
   npm install nexus-future
   ```

- cli name:

   before:

   ```
   $ santa
   ```

   now:

   ```
   $ nexus-future
   ```

- plugin package name prefix convention

   before:

   ```
   graphql-santa-*
   ```

   now:

   ```
   nexus-*
   ```


#### TODO

- [x] docs
- [x] ~tests~