### PR TITLE
fix(testing): TestContextCore for internal

### DIFF
--- a/src/core/plugin/index.ts
+++ b/src/core/plugin/index.ts
@@ -4,9 +4,14 @@ import * as Path from 'path'
 import prompts, * as Prompts from 'prompts'
 import * as Layout from '../../framework/layout'
 import { NexusConfig } from '../../framework/nexus'
-import { TestContext } from '../../framework/testing'
+import { TestContextCore } from '../../framework/testing'
 import * as Logger from '../../lib/logger'
-import { CallbackRegistrer, MaybePromise, SideEffector } from '../../lib/utils'
+import {
+  CallbackRegistrer,
+  DeepPartial,
+  MaybePromise,
+  SideEffector,
+} from '../../lib/utils'
 import { fatal, pog, run, runSync } from '../../utils'
 import * as PackageManager from '../../utils/package-manager'
 import * as Chokidar from '../../watcher/chokidar'
@@ -137,11 +142,7 @@ export type RuntimeContributions<C extends {} = any> = {
 
 type RuntimePlugin = () => RuntimeContributions
 
-type DeepPartial<T extends Record<string, any>> = {
-  [P in keyof T]?: T[P] extends Record<string, any> ? DeepPartial<T[P]> : T[P]
-} & { [x: string]: any }
-
-export type TestingContributions = DeepPartial<TestContext>
+export type TestingContributions = DeepPartial<TestContextCore>
 
 type TestingPlugin = () => TestingContributions
 

--- a/src/framework/testing.ts
+++ b/src/framework/testing.ts
@@ -20,14 +20,20 @@ export function createAppClient(apiUrl: string): AppClient {
   }
 }
 
-declare global {
-  interface nexusFutureTestContextApp {
-    query: AppClient['query']
-    server: {
-      start: () => Promise<void>
-      stop: () => Promise<void>
-    }
+interface TestContextAppCore {
+  query: AppClient['query']
+  server: {
+    start: () => Promise<void>
+    stop: () => Promise<void>
   }
+}
+
+interface TestContextCore {
+  app: TestContextAppCore
+}
+
+declare global {
+  interface nexusFutureTestContextApp extends TestContextAppCore {}
 
   interface nexusFutureTestContextRoot {
     app: nexusFutureTestContextApp
@@ -85,7 +91,7 @@ export async function createTestContext(): Promise<TestContext> {
   }
 
   const appClient = createAppClient(apiUrl)
-  const testContext: TestContext = {
+  const testContext: TestContextCore = {
     app: {
       query: appClient.query,
       server: {

--- a/src/framework/testing.ts
+++ b/src/framework/testing.ts
@@ -20,7 +20,7 @@ export function createAppClient(apiUrl: string): AppClient {
   }
 }
 
-interface TestContextAppCore {
+export interface TestContextAppCore {
   query: AppClient['query']
   server: {
     start: () => Promise<void>
@@ -28,7 +28,7 @@ interface TestContextAppCore {
   }
 }
 
-interface TestContextCore {
+export interface TestContextCore {
   app: TestContextAppCore
 }
 

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -4,6 +4,10 @@ export type CallbackRegistrer<F> = (f: F) => void
 
 export type SideEffector = () => MaybePromise
 
+export type DeepPartial<T extends Record<string, any>> = {
+  [P in keyof T]?: T[P] extends Record<string, any> ? DeepPartial<T[P]> : T[P]
+} & { [x: string]: any }
+
 /**
  * Guarantee the length of a given string, padding before or after with the
  * given character. If the given string is longer than  the span target, then it


### PR DESCRIPTION
This change provides a test context type for internal use that is not
extensible by plugins. Without this a user's app that has plugins that
extend test context will fail to copmile (unless skip lib check is on).


#### TODO

- [x] ~docs~
- [x] ~tests~