### PR TITLE
feat: app.schema namespace

### DIFF
--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -56,7 +56,7 @@ We're going to need to expose the `moons` world field to clients
 
 ```diff
 +++ src/schema.ts
-  app.objectType({
+  app.schema.objectType({
     name: "World",
     definition(t) {
       t.model.id()
@@ -84,7 +84,7 @@ The feedback is pretty clear already but to restate: The problem is that we're p
 
 ```diff
 +++ src/schema.ts
-+app.objectType({
++app.schema.objectType({
 +  name:'Moon',
 +  definition(t){
 +    t.model.id()
@@ -104,7 +104,7 @@ If you go to your GraphQL Playground now you will see that your GraphQL schema n
 
 ```diff
 +++ src/schema.ts
-+app.mutationType({
++app.schema.mutationType({
 +  definition(t){
 +    t.crud.updateOneWorld()
 +  }

--- a/docs/references/api.md
+++ b/docs/references/api.md
@@ -1,6 +1,10 @@
 ## `app`
 
-A singleton `nexus` app. Use this to build up your GraphQL schema and configure your server.
+A singleton `nexus` app. Use this to build up your GraphQL schema and server.
+
+### `app.schema`
+
+An instance of [`Schema`](#schema).
 
 **Example**
 
@@ -9,51 +13,7 @@ A singleton `nexus` app. Use this to build up your GraphQL schema and configure 
 
 import { app } from 'nexus-future'
 
-app.objectType({
-  name: 'Foo',
-  definition(t) {
-    t.id('id')
-  },
-})
-```
-
-### `app.addToContext`
-
-Add context to your graphql resolver functions. The objects returned by your context contributor callbacks will be shallow-merged into `ctx`. The `ctx` type will also accurately reflect the types you return from callbacks passed to `addToContext`.
-
-**Example**
-
-```ts
-// app.ts
-
-import { app } from 'nexus-future'
-
-app.addToContext(req => {
-  return {
-    foo: 'bar',
-  }
-})
-
-app.objectType({
-  name: 'Foo',
-  definition(t) {
-    t.string('foo', (_parent, _args, ctx) => ctx.foo)
-  },
-})
-```
-
-### `app.<nexusDefBlock>`
-
-Add types to your GraphQL Schema. The available nexus definition block functions include `objectType` `inputObjectType` `enumType` and so on. Refer to the [official Nexus API documentation](https://nexus.js.org/docs/api-objecttype) for more information about these functions.
-
-**Example**
-
-```ts
-// schema.ts
-
-import { app } from 'nexus-future'
-
-app.objectType({
+app.schema.objectType({
   name: 'Foo',
   definition(t) {
     t.id('id')
@@ -81,7 +41,40 @@ An instance of [`Server`](#server).
 
 Framework Notes:
 
-- If your app does not call `app.server.start` then `nexus` will. It is idiomatic to allow `nexus` to take care of this. If you deviate, we would love to learn about your use-case!
+- If your app does not call `app.server.start` then `nexus` will. It is
+  idiomatic to allow `nexus` to take care of this. If you deviate, we would love
+  to learn about your use-case!
+
+## `Schema`
+
+### `schema.addToContext`
+
+Add context to your graphql resolver functions. The objects returned by your context contributor callbacks will be shallow-merged into `ctx`. The `ctx` type will also accurately reflect the types you return from callbacks passed to `addToContext`.
+
+**Example**
+
+```ts
+// app.ts
+
+import { app } from 'nexus-future'
+
+app.schema.addToContext(req => {
+  return {
+    foo: 'bar',
+  }
+})
+
+app.schema.objectType({
+  name: 'Foo',
+  definition(t) {
+    t.string('foo', (_parent, _args, ctx) => ctx.foo)
+  },
+})
+```
+
+### `schema.<nexusDefBlock>`
+
+Add types to your GraphQL Schema. The available nexus definition block functions include `objectType` `inputObjectType` `enumType` and so on. Refer to the [official Nexus API documentation](https://nexus.js.org/docs/api-objecttype) for more information about these functions.
 
 ## `Server`
 

--- a/src/cli/commands/create/app.ts
+++ b/src/cli/commands/create/app.ts
@@ -351,7 +351,7 @@ async function helloWorldTemplate(layout: Layout.Layout) {
     stripIndent`
     import { app } from "nexus-future";
 
-    app.addToContext(req => {
+    app.schema.addToContext(req => {
       return {
         db: {
           worlds: [
@@ -362,7 +362,7 @@ async function helloWorldTemplate(layout: Layout.Layout) {
       }
     })
 
-    app.objectType({
+    app.schema.objectType({
       name: "World",
       definition(t) {
         t.id("id")
@@ -371,7 +371,7 @@ async function helloWorldTemplate(layout: Layout.Layout) {
       }
     })
 
-    app.queryType({
+    app.schema.queryType({
       definition(t) {        
         t.field("hello", {
           type: "World",

--- a/src/framework/app.ts
+++ b/src/framework/app.ts
@@ -31,29 +31,49 @@ type Request = HTTP.IncomingMessage & { logger: Logger.Logger }
 type ContextContributor<T extends {}> = (req: Request) => T
 
 export type App = {
-  use: (plugin: Plugin.Driver) => App
-  logger: Logger.RootLogger
-  addToContext: <T extends {}>(contextContributor: ContextContributor<T>) => App
   // installGlobally: () => App
+  use: (plugin: Plugin.Driver) => App
+  /**
+   * [API Reference](https://nexus-future.now.sh/#/references/api?id=logger)  ⌁  [Guide](https://nexus-future.now.sh/#/guides/logging)
+   *
+   * ### todo
+   */
+  logger: Logger.RootLogger
+  /**
+   * [API Reference](https://nexus-future.now.sh/#/references/api?id=server)  ⌁  [Guide](todo)
+   *
+   * ### todo
+   *
+   */
   server: {
     start: (config?: ServerOptions) => Promise<void>
     stop: () => Promise<void>
   }
-  queryType: typeof nexus.queryType
-  mutationType: typeof nexus.mutationType
-  objectType: typeof nexus.objectType
-  inputObjectType: typeof nexus.inputObjectType
-  enumType: typeof nexus.enumType
-  scalarType: typeof nexus.scalarType
-  unionType: typeof nexus.unionType
-  interfaceType: typeof nexus.interfaceType
-  intArg: typeof nexus.intArg
-  stringArg: typeof nexus.stringArg
-  booleanArg: typeof nexus.booleanArg
-  floatArg: typeof nexus.floatArg
-  idArg: typeof nexus.idArg
-  extendType: typeof nexus.extendType
-  extendInputType: typeof nexus.extendInputType
+  /**
+   * [API Reference](https://nexus-future.now.sh/#/references/api?id=appschema) // [Guide](todo)
+   *
+   * ### todo
+   */
+  schema: {
+    addToContext: <T extends {}>(
+      contextContributor: ContextContributor<T>
+    ) => App
+    queryType: typeof nexus.queryType
+    mutationType: typeof nexus.mutationType
+    objectType: typeof nexus.objectType
+    inputObjectType: typeof nexus.inputObjectType
+    enumType: typeof nexus.enumType
+    scalarType: typeof nexus.scalarType
+    unionType: typeof nexus.unionType
+    interfaceType: typeof nexus.interfaceType
+    intArg: typeof nexus.intArg
+    stringArg: typeof nexus.stringArg
+    booleanArg: typeof nexus.booleanArg
+    floatArg: typeof nexus.floatArg
+    idArg: typeof nexus.idArg
+    extendType: typeof nexus.extendType
+    extendInputType: typeof nexus.extendInputType
+  }
 }
 
 /**
@@ -112,25 +132,27 @@ export function createApp(appConfig?: { types?: any }): App {
       }
       return api
     },
-    addToContext(contextContributor) {
-      contextContributors.push(contextContributor)
-      return api
+    schema: {
+      addToContext(contextContributor) {
+        contextContributors.push(contextContributor)
+        return api
+      },
+      queryType,
+      mutationType,
+      objectType,
+      inputObjectType,
+      enumType,
+      scalarType,
+      unionType,
+      interfaceType,
+      intArg,
+      stringArg,
+      booleanArg,
+      floatArg,
+      idArg,
+      extendType,
+      extendInputType,
     },
-    queryType,
-    mutationType,
-    objectType,
-    inputObjectType,
-    enumType,
-    scalarType,
-    unionType,
-    interfaceType,
-    intArg,
-    stringArg,
-    booleanArg,
-    floatArg,
-    idArg,
-    extendType,
-    extendInputType,
     server: {
       /**
        * Start the server. If you do not call this explicitly then nexus will
@@ -297,7 +319,7 @@ const installGlobally = (app: App): App => {
     intArg,
     stringArg,
     //TODO rest of the statics...
-  } = app
+  } = app.schema
 
   Object.assign(global, {
     app,

--- a/test/integration/build.spec.ts
+++ b/test/integration/build.spec.ts
@@ -27,7 +27,7 @@ it('can build with just a schema module', () => {
     `
       import { app } from 'nexus-future'
 
-      app.objectType({
+      app.schema.objectType({
         name: 'A',
         definition(t) {
           t.string('a')
@@ -47,7 +47,7 @@ it('can build with just a schema folder of modules', () => {
     `
       import { app } from 'nexus-future'
 
-      app.objectType({
+      app.schema.objectType({
         name: 'A',
         definition(t) {
           t.string('a')
@@ -67,7 +67,7 @@ it('can build with schema + app modules', () => {
     `
       import { app } from 'nexus-future'
 
-      app.objectType({
+      app.schema.objectType({
         name: 'A',
         definition(t) {
           t.string('a')
@@ -95,7 +95,7 @@ it('can nest modules', () => {
     `
       import { app } from 'nexus-future'
 
-      app.objectType({
+      app.schema.objectType({
         name: 'A',
         definition(t) {
           t.string('a')
@@ -164,7 +164,7 @@ it('can build a plugin', () => {
         }	
       })	
 
-      app.objectType({	
+      app.schema.objectType({	
         name: 'Foo',	
         definition(t) {	
           t.string('bar')	

--- a/test/integration/prisma/build.spec.ts
+++ b/test/integration/prisma/build.spec.ts
@@ -28,7 +28,7 @@ it('can build a prisma framework project', () => {
     `
       import { app } from 'nexus-future'
 
-      app.objectType({
+      app.schema.objectType({
         name: 'User',
         definition(t) {
           t.model.id()


### PR DESCRIPTION
#### Why

- supports the mental model
- gives room for the root api surface to grow comfortably
- autocomplete becomes a lot more useful to discover the api
- to address the "but this increases typing" personally still believe in a the global mode concept. I foresee power users opting into "global schema mode" where schema functions are made accessible from anywhere
- we can put js doc annotation on schema prop linking with docs entrypoint for schema
- logical place to add more schema functions. for example the upcoming [`.settings` feature](https://github.com/graphql-nexus/nexus-future/issues/117#issuecomment-580481021)

BREAKING CHANGE:
- all schema related properties and functions are now found under
  `app.schema`. Previously they were directly on `app`.


#### TODO

- [x] docs
- [x] tests
- [x] scaffold templates