### PR TITLE
feat(core): app props as named exports

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,9 +15,9 @@ Here are some of the things `nexus` cares about:
 Here is what a hello world looks like:
 
 ```ts
-import { app } from 'nexus-future'
+import { schema } from 'nexus-future'
 
-app.queryType({
+schema.queryType({
   definition(t) {
     t.field('hello', {
       type: 'World',
@@ -31,7 +31,7 @@ app.queryType({
   },
 })
 
-app.objectType({
+schema.objectType({
   name: 'World',
   definition(t) {
     t.string('name')

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -56,7 +56,7 @@ We're going to need to expose the `moons` world field to clients
 
 ```diff
 +++ src/schema.ts
-  app.schema.objectType({
+  schema.objectType({
     name: "World",
     definition(t) {
       t.model.id()
@@ -84,7 +84,7 @@ The feedback is pretty clear already but to restate: The problem is that we're p
 
 ```diff
 +++ src/schema.ts
-+app.schema.objectType({
++schema.objectType({
 +  name:'Moon',
 +  definition(t){
 +    t.model.id()
@@ -104,7 +104,7 @@ If you go to your GraphQL Playground now you will see that your GraphQL schema n
 
 ```diff
 +++ src/schema.ts
-+app.schema.mutationType({
++schema.mutationType({
 +  definition(t){
 +    t.crud.updateOneWorld()
 +  }

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -4,12 +4,12 @@ Logging is one of the primary means for knowing what is going on at runtime, wha
 
 It is recommended that your app only sends to stdout via the `nexus` logging system. This ensures that you maintain log level control and are always working with JSON. We work hard to make the logger so good that you'll to use it.
 
-- Applications can get a reference to a logger singleton at `app.logger`.
+- Applications can get a reference to a logger singleton at `logger`.
 
   ```ts
-  import { app } from 'nexus-future'
+  import { logger } from 'nexus-future'
 
-  app.logger.info('hello')
+  logger.info('hello')
   ```
 
 - Logs are formatted as JSON and then sent to `stdout`.
@@ -21,7 +21,7 @@ It is recommended that your app only sends to stdout via the `nexus` logging sys
 - This approach gets you significantly more leverage out of your logs once they hit your logging platform, e.g. [ELK](https://www.elastic.co/what-is/elk-stack)
 - The first parameter of the log function is the event name and hence maps to the `event` field in the output JSON.
   ```ts
-  app.logger.info('hello')
+  logger.info('hello')
   // { "event": "hello", ... }
   ```
 
@@ -29,31 +29,31 @@ It is recommended that your app only sends to stdout via the `nexus` logging sys
 
 - The second parameter is optional contextual information. The object passed here is nested under the `context` field in the output JSON.
   ```ts
-  app.logger.info('hello', { user: 'Toto' })
+  logger.info('hello', { user: 'Toto' })
   // { "context": { "user": "Toto"  }, ... }
   ```
 - If you have some information that you wish all logs to include in their context you can do this:
   ```ts
-  app.logger.addToContext({ user: 'Toto' })
-  app.logger.info('hello')
-  app.logger.warn('bye')
+  logger.addToContext({ user: 'Toto' })
+  logger.info('hello')
+  logger.warn('bye')
   // { "context": { "user": "Toto"  }, "event": "hello", ... }
   // { "context": { "user": "Toto"  }, "event": "bye", ... }
   ```
 - Data is [merged deeply](https://lodash.com/docs/4.17.15#merge). When scalars conflict the most local takes precedence
   ```ts
-  app.logger.addToContext({ user: { name: 'Toto', age: 10 })
-  app.logger.info("hi", { user: { name: 'Titi', heightCM: 155 })
+  logger.addToContext({ user: { name: 'Toto', age: 10 })
+  logger.info("hi", { user: { name: 'Titi', heightCM: 155 })
   // { "context": { "user": { "name": "Titi", age: 10, heightCM: 155 }}, ... }
   ```
 - [child loggers](#child-loggers) inherit context from their parent and can add their own context but cannot modify their parents'
 
   ```ts
-  app.logger.addToContext({ user: 'Toto' })
-  const bar = app.logger.child('bar').addToContext({ bar: 'bar' })
-  const foo = app.logger.child('foo').addToContext({ foo: 'foo' })
+  logger.addToContext({ user: 'Toto' })
+  const bar = logger.child('bar').addToContext({ bar: 'bar' })
+  const foo = logger.child('foo').addToContext({ foo: 'foo' })
 
-  app.logger.info('hello')
+  logger.info('hello')
   bar.info('bar')
   foo.info('foo')
 
@@ -94,11 +94,11 @@ You can create child loggers recursively starting from the root logger. A child 
 
 Child loggers are useful when you want to pass a logger to something that should be tracked as its own subsystem and/or may add context that you want isolated from the rest of the system. For example a classic use-case is the logger-instance-per-request pattern where a request-scoped logger is used for all logs in a request-response code path. This makes it much easier in production to group logs in your logging platform by request-response lifecycles.
 
-All runtime logs in your app (including from plugins ([bug #300](https://github.com/graphql-nexus/nexus-future/issues/300))) come from either the `app.logger` itself or descendents thereof. This means if you wish absolutely every log being emitted by your app to contain some additional context you can do so simply by adding context to the root logger:
+All runtime logs in your app (including from plugins ([bug #300](https://github.com/graphql-nexus/nexus-future/issues/300))) come from either the `logger` itself or descendents thereof. This means if you wish absolutely every log being emitted by your app to contain some additional context you can do so simply by adding context to the root logger:
 
 ```ts
-app.logger.addToContext({ user: 'Toto' })
-app.logger
+logger.addToContext({ user: 'Toto' })
+logger
   .child('a')
   .child('b')
   .child('c')

--- a/docs/references/api.md
+++ b/docs/references/api.md
@@ -1,19 +1,19 @@
-## `app`
+## Modules
 
-A singleton `nexus` app. Use this to build up your GraphQL schema and server.
+### `nexus-future`
 
-### `app.schema`
+Exports the singleton app components. Use to build up your GraphQL schema and server.
+
+#### `schema`
 
 An instance of [`Schema`](#schema).
 
 **Example**
 
 ```ts
-// schema.ts
+import { schema } from 'nexus-future'
 
-import { app } from 'nexus-future'
-
-app.schema.objectType({
+schema.objectType({
   name: 'Foo',
   definition(t) {
     t.id('id')
@@ -21,37 +21,51 @@ app.schema.objectType({
 })
 ```
 
-### `app.logger`
+#### `logger`
 
 An instance of [`RootLogger`](#rootlogger).
 
 **Example**
 
 ```ts
-// app.ts
+import { logger } from 'nexus-future'
 
-import { app } from 'nexus-future'
-
-app.logger.info('boot')
+logger.info('boot')
 ```
 
-### `app.server`
+#### `server`
 
 An instance of [`Server`](#server).
 
+**Example**
+
+```ts
+import { server } from 'nexus-future'
+
+server.start()
+```
+
 Framework Notes:
 
-- If your app does not call `app.server.start` then `nexus` will. It is
-  idiomatic to allow `nexus` to take care of this. If you deviate, we would love
-  to learn about your use-case!
+- If your app does not call `server.start` then `nexus` will. It is idiomatic to allow `nexus` to take care of this. If you deviate, we would love to learn about your use-case!
 
-## `Schema`
-
-### `schema.settings`
+### `nexus-future/testing`
 
 todo
 
-### `schema.addToContext`
+### `nexus-future/plugin`
+
+todo
+
+## Types
+
+### `Schema`
+
+#### `schema.settings`
+
+todo
+
+#### `schema.addToContext`
 
 Add context to your graphql resolver functions. The objects returned by your context contributor callbacks will be shallow-merged into `ctx`. The `ctx` type will also accurately reflect the types you return from callbacks passed to `addToContext`.
 
@@ -60,15 +74,15 @@ Add context to your graphql resolver functions. The objects returned by your con
 ```ts
 // app.ts
 
-import { app } from 'nexus-future'
+import { schema } from 'nexus-future'
 
-app.schema.addToContext(req => {
+schema.addToContext(req => {
   return {
     foo: 'bar',
   }
 })
 
-app.schema.objectType({
+schema.objectType({
   name: 'Foo',
   definition(t) {
     t.string('foo', (_parent, _args, ctx) => ctx.foo)
@@ -76,44 +90,44 @@ app.schema.objectType({
 })
 ```
 
-### `schema.<nexusDefBlock>`
+#### `schema.<nexusDefBlock>`
 
 Add types to your GraphQL Schema. The available nexus definition block functions include `objectType` `inputObjectType` `enumType` and so on. Refer to the [official Nexus Schema API documentation](https://nexus.js.org/docs/api-objecttype) for more information about these functions.
 
-## `Server`
+### `Server`
 
 TODO
 
-### `server.start`
+#### `server.start`
 
-### `server.stop`
+#### `server.stop`
 
-## `RootLogger`
+### `RootLogger`
 
 TODO
 
 Extends [`Logger`](#logger)
 
-### `rootLogger.settings`
+#### `rootLogger.settings`
 
-## `Logger`
+### `Logger`
 
 TODO
 
-### `.create`
+#### `.create`
 
-### `logger.fatal`
+#### `logger.fatal`
 
-### `logger.error`
+#### `logger.error`
 
-### `logger.warn`
+#### `logger.warn`
 
-### `logger.info`
+#### `logger.info`
 
-### `logger.debug`
+#### `logger.debug`
 
-### `logger.trace`
+#### `logger.trace`
 
-### `logger.addToContext`
+#### `logger.addToContext`
 
-### `logger.child`
+#### `logger.child`

--- a/src/cli/commands/create/app.ts
+++ b/src/cli/commands/create/app.ts
@@ -349,9 +349,9 @@ async function helloWorldTemplate(layout: Layout.Layout) {
   await fs.writeAsync(
     layout.sourcePath('schema.ts'),
     stripIndent`
-    import { app } from "nexus-future";
+    import { schema } from "nexus-future";
 
-    app.schema.addToContext(req => {
+    schema.addToContext(req => {
       return {
         db: {
           worlds: [
@@ -362,7 +362,7 @@ async function helloWorldTemplate(layout: Layout.Layout) {
       }
     })
 
-    app.schema.objectType({
+    schema.objectType({
       name: "World",
       definition(t) {
         t.id("id")
@@ -371,12 +371,12 @@ async function helloWorldTemplate(layout: Layout.Layout) {
       }
     })
 
-    app.schema.queryType({
+    schema.queryType({
       definition(t) {        
         t.field("hello", {
           type: "World",
           args: {
-            world: app.stringArg({ required: false })
+            world: schema.stringArg({ required: false })
           },
           resolve(_root, args, ctx) {
             const worldToFindByName = args.world || "Earth"

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -1,13 +1,7 @@
-import { createApp } from './app'
+import * as App from './app'
 
-// TODO Pending future discussion
-// declare global {
-//   interface PumpkinsSingletonApp {}
-// }
-//
-// if (isGlobalSingletonEnabled()) {
-//   app = createApp()
-//   ;(app as any).installGlobally()
-// }
+const app = App.create()
+const { logger, schema, server } = app
 
-export const app = createApp()
+export default app
+export { logger, schema, server }

--- a/src/framework/start.ts
+++ b/src/framework/start.ts
@@ -74,7 +74,7 @@ export function createStartModuleContent(config: StartModuleConfig): string {
         // Users should normally not boot the server manually as doing so does not
         // bring value to the user's codebase.
 
-        const { app } = require('nexus-future')
+        const app = require('nexus-future')
         const singletonChecks = require('nexus-future/dist/framework/singleton-checks')
 
         if (singletonChecks.state.is_was_server_start_called === false) {
@@ -83,7 +83,7 @@ export function createStartModuleContent(config: StartModuleConfig): string {
         `
     : stripIndent`
         // Start the server
-        const { app } = require('nexus-future')
+        const app = require('nexus-future')
         app.server.start()
       `
 

--- a/src/framework/testing.ts
+++ b/src/framework/testing.ts
@@ -2,7 +2,7 @@ import getPort from 'get-port'
 import { GraphQLClient } from 'graphql-request'
 import * as Lo from 'lodash'
 import * as Plugin from '../core/plugin'
-import { app } from './index'
+import * as app from './index'
 import * as Layout from './layout'
 import * as singletonChecks from './singleton-checks'
 

--- a/test/integration/build.spec.ts
+++ b/test/integration/build.spec.ts
@@ -25,7 +25,7 @@ it('can build with just a schema module', () => {
   ws.fs.write(
     'schema.ts',
     `
-      import { app } from 'nexus-future'
+      import app from 'nexus-future'
 
       app.schema.objectType({
         name: 'A',
@@ -45,7 +45,7 @@ it('can build with just a schema folder of modules', () => {
   ws.fs.write(
     'schema/a.ts',
     `
-      import { app } from 'nexus-future'
+      import app from 'nexus-future'
 
       app.schema.objectType({
         name: 'A',
@@ -65,7 +65,7 @@ it('can build with schema + app modules', () => {
   ws.fs.write(
     'schema.ts',
     `
-      import { app } from 'nexus-future'
+      import app from 'nexus-future'
 
       app.schema.objectType({
         name: 'A',
@@ -79,7 +79,7 @@ it('can build with schema + app modules', () => {
   ws.fs.write(
     'app.ts',
     `
-      import { app } from 'nexus-future'
+      import app from 'nexus-future'
       app.server.start()
     `
   )
@@ -93,7 +93,7 @@ it('can nest modules', () => {
   ws.fs.write(
     'graphql/schema.ts',
     `
-      import { app } from 'nexus-future'
+      import app from 'nexus-future'
 
       app.schema.objectType({
         name: 'A',
@@ -107,7 +107,7 @@ it('can nest modules', () => {
   ws.fs.write(
     'graphql/app.ts',
     `
-      import { app } from 'nexus-future'
+      import app from 'nexus-future'
       app.server.start()
     `
   )
@@ -148,7 +148,7 @@ it('can build a plugin', () => {
   ws.fs.write(
     'schema.ts',
     `
-      import { app } from 'nexus-future'
+      import app from 'nexus-future'
 
       app.queryType({	
         definition(t) {	
@@ -176,7 +176,7 @@ it('can build a plugin', () => {
   ws.fs.write(
     'app.ts',
     `	
-      import { app } from 'nexus-future'
+      import app from 'nexus-future'
       import myplugin from './myplugin'	
 
       app.use(myplugin).server.start()	

--- a/test/integration/prisma/build.spec.ts
+++ b/test/integration/prisma/build.spec.ts
@@ -26,7 +26,7 @@ it('can build a prisma framework project', () => {
   ws.fs.write(
     'schema.ts',
     `
-      import { app } from 'nexus-future'
+      import app from 'nexus-future'
 
       app.schema.objectType({
         name: 'User',


### PR DESCRIPTION
closes #361

BREAKING CHANGE:

- Users no longer can access `app` as named import. Its properties are now themselves named exports.

#### TODO

- [x] docs
- [x] ~tests~