### PR TITLE
feat(settings): add new system component

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,1 +1,1 @@
-`nexus` does not yet have a configuration system. We are working on its design in [#297](https://github.com/graphql-nexus/nexus-future/issues/297).
+## TODO

--- a/docs/references/api.md
+++ b/docs/references/api.md
@@ -23,7 +23,7 @@ schema.objectType({
 
 #### `log`
 
-An instance of [`RootLogger`](#rootlogger).
+An instance of [`Logger`](#logger).
 
 **Example**
 
@@ -48,6 +48,25 @@ server.start()
 Framework Notes:
 
 - If your app does not call `server.start` then `nexus` will. It is idiomatic to allow `nexus` to take care of this. If you deviate, we would love to learn about your use-case!
+
+#### `settings`
+
+An instance of [`Settings`](#settings).
+
+**Example**
+
+```ts
+import { log, settings } from 'nexus-future'
+
+settings.change({
+  server: {
+    startMessage: info => {
+      settings.original.server.startMessage(info)
+      log.warn('stowaway message! :p')
+    },
+  },
+})
+```
 
 ### `nexus-future/testing`
 
@@ -102,14 +121,6 @@ TODO
 
 #### `server.stop`
 
-### `RootLogger`
-
-TODO
-
-Extends [`Logger`](#logger)
-
-#### `rootLogger.settings`
-
 ### `Logger`
 
 TODO
@@ -131,3 +142,13 @@ TODO
 #### `logger.addToContext`
 
 #### `logger.child`
+
+### `Settings`
+
+TODO
+
+#### `change`
+
+#### `current`
+
+#### `original`

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -1,7 +1,18 @@
 import * as App from './app'
 
 const app = App.create()
-const { log, schema, server, settings } = app
 
 export default app
-export { log, schema, server, settings }
+
+// Destructure app for export
+// Do not use destructuring syntax
+// Breaks jsdoc, only first destructed member annotated
+// todo jsdoc
+
+export const log = app.log
+
+export const schema = app.schema
+
+export const server = app.server
+
+export const settings = app.settings

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -1,7 +1,7 @@
 import * as App from './app'
 
 const app = App.create()
-const { log, schema, server } = app
+const { log, schema, server, settings } = app
 
 export default app
-export { log, schema, server }
+export { log, schema, server, settings }

--- a/src/framework/schema/index.ts
+++ b/src/framework/schema/index.ts
@@ -1,3 +1,3 @@
 export { findDirOrModules, importModules, printStaticImports } from './modules'
 export { createInternalConfig } from './nexus'
-export { create, Schema } from './schema'
+export { create, Schema, SettingsData, SettingsInput } from './schema'

--- a/src/framework/server.ts
+++ b/src/framework/server.ts
@@ -15,7 +15,7 @@ const log = Logger.create({ name: 'server' })
  * The default server options. These are merged with whatever you provide. Your
  * settings take precedence over these.
  */
-const optDefaults: Required<ExtraOptions> = {
+export const defaultExtraSettings: Required<ExtraSettingsInput> = {
   port:
     typeof process.env.NEXUS_PORT === 'string'
       ? parseInt(process.env.NEXUS_PORT, 10)
@@ -33,8 +33,14 @@ const optDefaults: Required<ExtraOptions> = {
   playground: process.env.NODE_ENV === 'production' ? false : true,
 }
 
-type ExtraOptions = {
+export type ExtraSettingsInput = {
+  /**
+   * todo
+   */
   port?: number
+  /**
+   * todo
+   */
   playground?: boolean
   /**
    * Create a message suitable for printing to the terminal about the server
@@ -43,19 +49,21 @@ type ExtraOptions = {
   startMessage?: (address: { port: number; host: string; ip: string }) => void
 }
 
+export type ExtraSettingsData = Required<ExtraSettingsInput>
+
 /**
  * The available server options to configure how your app runs its server.
  */
-export type Options = createExpressGraphql.OptionsData &
-  ExtraOptions & {
+export type SettingsInput = createExpressGraphql.OptionsData &
+  ExtraSettingsInput & {
     plugins: Plugin.RuntimeContributions[]
     contextContributors: ContextContributor<any>[]
   }
 
-export function create(optsGiven: Options) {
+export function create(settingsGiven: SettingsInput) {
   const http = HTTP.createServer()
   const express = createExpress()
-  const opts = { ...optDefaults, ...optsGiven }
+  const opts = { ...defaultExtraSettings, ...settingsGiven }
 
   http.on('request', express)
 

--- a/src/framework/testing.ts
+++ b/src/framework/testing.ts
@@ -79,12 +79,16 @@ export async function createTestContext(): Promise<TestContext> {
       require(appModule)
     }
 
-    if (singletonChecks.state.is_was_server_start_called === false) {
-      await oldServerStart({
+    app.settings.change({
+      server: {
         port,
         playground: false,
         startMessage: () => '',
-      })
+      },
+    })
+
+    if (singletonChecks.state.is_was_server_start_called === false) {
+      await oldServerStart()
     } else {
       return Promise.resolve()
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,4 @@
+import app from './framework'
+
 export * from './framework'
+export default app

--- a/src/lib/logger/index.ts
+++ b/src/lib/logger/index.ts
@@ -1,3 +1,3 @@
 export { demo } from './demo'
 export { Logger } from './logger'
-export { create, RootLogger } from './root-logger'
+export { create, RootLogger, SettingsData, SettingsInput } from './root-logger'


### PR DESCRIPTION
closes #297

BREAKING CHANGE:

- Settings that used to be passed to `server.start` are now under `server` key in settings input.

- `log.settings` no longer exists. Settings that used to be passed to it are now under `logger` key in settings input.

- `schema.settings` no longer exists. Settings that used to be passed to it are now under `schema` key in settings input.

#### TODO

- [x] docs
- [x] ~tests~