### PR TITLE
feat: add server.custom api

### DIFF
--- a/src/framework/app.ts
+++ b/src/framework/app.ts
@@ -182,7 +182,7 @@ export function create(): App {
           const customServer = await customServerHook({
             schema: compiledSchema,
             defaultServer,
-            settings: settings.current,
+            settings: settings.current.server,
           })
 
           if (!customServer.start) {

--- a/src/framework/app.ts
+++ b/src/framework/app.ts
@@ -17,7 +17,7 @@ type Request = HTTP.IncomingMessage & { log: Logger.Logger }
 // all places in the framework where the req object is referenced should be
 // actually referencing the typegen version, so that it reflects the req +
 // plugin augmentations type
-type ContextContributor<T extends {}> = (req: Request) => T
+type ContextContributor<Req, T extends {} = any> = (req: Req) => T
 
 export type App = {
   /**
@@ -32,7 +32,7 @@ export type App = {
    * ### todo
    *
    */
-  server: Server.ServerWithCustom
+  server: Server.ServerWithCustomizer
   /**
    * todo
    */
@@ -49,8 +49,8 @@ export type App = {
     /**
      * todo
      */
-    addToContext: <T extends {}>(
-      contextContributor: ContextContributor<T>
+    addToContext: <Req extends any = Request, T extends {} = any>(
+      contextContributor: ContextContributor<Req, T>
     ) => void
   }
 }
@@ -140,7 +140,7 @@ export function create(): App {
        * Start the server. If you do not call this explicitly then nexus will
        * for you. You should not normally need to call this function yourself.
        */
-      async start(): Promise<void> {
+      async start() {
         // Track the start call so that we can know in entrypoint whether to run
         // or not start for the user.
         singletonChecks.state.is_was_server_start_called = true
@@ -175,7 +175,7 @@ export function create(): App {
       stop() {
         return server.stop()
       },
-      async custom(customizer) {
+      custom(customizer) {
         server.setCustomizer(customizer)
       },
     },

--- a/src/framework/schema/config.ts
+++ b/src/framework/schema/config.ts
@@ -1,0 +1,144 @@
+import * as Nexus from '@nexus/schema'
+import { stripIndents } from 'common-tags'
+import * as fs from 'fs-jetpack'
+import * as Lo from 'lodash'
+import * as Plugin from '../../core/plugin'
+import { log } from './logger'
+import {
+  shouldExitAfterGenerateArtifacts,
+  shouldGenerateArtifacts,
+} from './nexus'
+
+export type NexusConfig = Nexus.core.SchemaConfig
+
+export function createInternalConfig(
+  plugins: Plugin.RuntimeContributions[]
+): NexusConfig {
+  const defaultConfig = createDefaultNexusConfig()
+
+  // Merge the plugin nexus plugins
+  defaultConfig.plugins = defaultConfig.plugins ?? []
+
+  for (const plugin of plugins) {
+    defaultConfig.plugins.push(...(plugin.nexus?.plugins ?? []))
+  }
+
+  const finalConfig = withAutoTypegenConfig(defaultConfig, plugins)
+
+  log.trace('built up schema config', { nexusConfig: finalConfig })
+
+  return finalConfig
+}
+
+function createDefaultNexusConfig(): NexusConfig {
+  const NEXUS_DEFAULT_TYPEGEN_PATH = fs.path(
+    'node_modules/@types/typegen-nexus/index.d.ts'
+  )
+  return {
+    outputs: {
+      schema: false,
+      typegen: NEXUS_DEFAULT_TYPEGEN_PATH,
+    },
+    typegenAutoConfig: {
+      sources: [],
+    },
+    shouldGenerateArtifacts: shouldGenerateArtifacts(),
+    shouldExitAfterGenerateArtifacts: shouldExitAfterGenerateArtifacts(),
+    types: [],
+  }
+}
+
+function withAutoTypegenConfig(
+  nexusConfig: NexusConfig,
+  plugins: Plugin.RuntimeContributions[]
+) {
+  // Integrate plugin typegenAutoConfig contributions
+  const typegenAutoConfigFromPlugins = {}
+  for (const p of plugins) {
+    if (p.nexus?.typegenAutoConfig) {
+      Lo.merge(typegenAutoConfigFromPlugins, p.nexus.typegenAutoConfig)
+    }
+  }
+
+  const typegenAutoConfigObject = Lo.merge(
+    {},
+    typegenAutoConfigFromPlugins,
+    nexusConfig.typegenAutoConfig!
+  )
+  nexusConfig.typegenAutoConfig = undefined
+
+  function contextTypeContribSpecToCode(
+    ctxTypeContribSpec: Record<string, string>
+  ): string {
+    return stripIndents`
+      interface Context {
+        ${Object.entries(ctxTypeContribSpec)
+          .map(([name, type]) => {
+            // Quote key name to handle case of identifier-incompatible key names
+            return `'${name}': ${type}`
+          })
+          .join('\n')}
+      }
+    `
+  }
+
+  // Our use-case of multiple context sources seems to require a custom
+  // handling of typegenConfig. Opened an issue about maybe making our
+  // curreent use-case, fairly basic, integrated into the auto system, here:
+  // https://github.com/prisma-labs/nexus/issues/323
+  nexusConfig.typegenConfig = async (schema, outputPath) => {
+    const configurator = await Nexus.core.typegenAutoConfig(
+      typegenAutoConfigObject
+    )
+    const config = await configurator(schema, outputPath)
+
+    // Initialize
+    config.imports.push('interface Context {}')
+    config.contextType = 'Context'
+
+    // Integrate user's app calls to app.addToContext
+    const addToContextCallResults: string[] = process.env
+      .NEXUS_TYPEGEN_ADD_CONTEXT_RESULTS
+      ? JSON.parse(process.env.NEXUS_TYPEGEN_ADD_CONTEXT_RESULTS)
+      : []
+
+    const addToContextInterfaces = addToContextCallResults
+      .map(result => {
+        return stripIndents`
+                    interface Context ${result}
+                  `
+      })
+      .join('\n\n')
+
+    config.imports.push(addToContextInterfaces)
+
+    // Integrate plugin context contributions
+    for (const p of plugins) {
+      if (!p.context) continue
+
+      if (p.context.typeGen.imports) {
+        config.imports.push(
+          ...p.context.typeGen.imports.map(
+            im => `import * as ${im.as} from '${im.from}'`
+          )
+        )
+      }
+
+      config.imports.push(
+        contextTypeContribSpecToCode(p.context.typeGen.fields)
+      )
+    }
+
+    config.imports.push(
+      "import * as Logger from 'nexus-future/dist/lib/logger'",
+      contextTypeContribSpecToCode({
+        log: 'Logger.Logger',
+      })
+    )
+
+    log.trace('built up Nexus typegenConfig', { config })
+    return config
+  }
+
+  return nexusConfig
+}

--- a/src/framework/schema/index.ts
+++ b/src/framework/schema/index.ts
@@ -1,3 +1,3 @@
+export { createInternalConfig } from './config'
 export { findDirOrModules, importModules, printStaticImports } from './modules'
-export { createInternalConfig } from './nexus'
 export { create, Schema, SettingsData, SettingsInput } from './schema'

--- a/src/framework/schema/nexus.ts
+++ b/src/framework/schema/nexus.ts
@@ -1,6 +1,5 @@
 import * as Nexus from '@nexus/schema'
 import { generateSchema } from '@nexus/schema/dist/core'
-import * as fs from 'fs-jetpack'
 
 export function createNexusSingleton() {
   const __types: any[] = []
@@ -115,35 +114,16 @@ export function createNexusSingleton() {
   }
 }
 
-export type NexusConfig = Nexus.core.SchemaConfig
-
-export function createInternalConfig(): NexusConfig {
-  const defaultTypesPath = fs.path(
-    'node_modules/@types/typegen-nexus/index.d.ts'
-  )
-
-  return {
-    outputs: {
-      schema: false,
-      typegen: defaultTypesPath,
-    },
-    typegenAutoConfig: {
-      sources: [],
-    },
-    shouldGenerateArtifacts: shouldGenerateArtifacts(),
-    shouldExitAfterGenerateArtifacts: shouldExitAfterGenerateArtifacts(),
-    types: [],
-  }
-}
-
-export const shouldGenerateArtifacts = (): boolean =>
-  process.env.NEXUS_SHOULD_GENERATE_ARTIFACTS === 'true'
+export function shouldGenerateArtifacts(): boolean {
+  return process.env.NEXUS_SHOULD_GENERATE_ARTIFACTS === 'true'
     ? true
     : process.env.NEXUS_SHOULD_GENERATE_ARTIFACTS === 'false'
     ? false
     : Boolean(!process.env.NODE_ENV || process.env.NODE_ENV === 'development')
+}
 
-export const shouldExitAfterGenerateArtifacts = (): boolean =>
-  process.env.NEXUS_SHOULD_EXIT_AFTER_GENERATE_ARTIFACTS === 'true'
+export function shouldExitAfterGenerateArtifacts(): boolean {
+  return process.env.NEXUS_SHOULD_EXIT_AFTER_GENERATE_ARTIFACTS === 'true'
     ? true
     : false
+}

--- a/src/framework/schema/schema.ts
+++ b/src/framework/schema/schema.ts
@@ -1,6 +1,7 @@
 import * as NexusSchema from '@nexus/schema'
 import { Param1 } from '../../lib/utils'
 import { createNexusSingleton } from './nexus'
+import { NexusGraphQLSchema, SchemaConfig } from '@nexus/schema/dist/core'
 
 type ConnectionPluginConfig = NonNullable<
   Param1<typeof NexusSchema.connectionPlugin>
@@ -62,7 +63,7 @@ export type Schema = {
 type SchemaInternal = {
   private: {
     types: any[]
-    compile: any
+    compile: (config: SchemaConfig) => Promise<NexusGraphQLSchema>
     settings: {
       data: SettingsData
       change: (newSettings: SettingsInput) => void
@@ -104,7 +105,7 @@ export function create(): SchemaInternal {
   const api: SchemaInternal = {
     private: {
       types: __types,
-      compile: (c: any) => {
+      compile: c => {
         c.plugins = c.plugins ?? []
         c.plugins.push(...processConnectionsConfig(state.settings))
         return makeSchema(c)

--- a/src/framework/server.ts
+++ b/src/framework/server.ts
@@ -79,7 +79,7 @@ export interface Server {
   stop(): Promise<void>
 }
 
-interface ExpressServerWithInstance extends Server {
+interface ServerWithExpressInstance extends Server {
   /**
    * The original Express server instance bundled with Nexus. Use it to add express middlewares or change its configuration in anyway
    */
@@ -115,7 +115,7 @@ export interface ServerWithCustomizer extends Server {
 
 function createExpressServer(
   settingsGiven: SettingsInput
-): ExpressServerWithInstance {
+): ServerWithExpressInstance {
   const http = HTTP.createServer()
   const express = createExpress()
   const opts = { ...defaultExtraSettings, ...settingsGiven }
@@ -281,7 +281,7 @@ export function create(): ServerFactory {
             server = createDefaultServer()
             log.debug('Augmented Express server used')
 
-            return (server as ExpressServerWithInstance).instance
+            return (server as ServerWithExpressInstance).instance
           },
           context: createContext,
         })

--- a/src/framework/server.ts
+++ b/src/framework/server.ts
@@ -85,7 +85,7 @@ interface ServerWithInstance<T extends any> extends Server {
 interface CustomServerHookInput {
   schema: GraphQL.GraphQLSchema
   defaultServer: ServerWithInstance<Express>
-  settings: App.SettingsData
+  settings: App.SettingsData['server']
 }
 
 export type CustomServerHook = (


### PR DESCRIPTION
closes #368, #369

## Description

- Add a `server.custom` api to provide custom server
- This API can also be used to access the underlying express instance

Usage examples:

**Using fastify**
```js
import { settings, server } from 'nexus-future'
import Fastify from 'fastify'
import GQL from 'fastify-gql'

server.custom(e => {
  const app = Fastify()

  return {
    async start() {
      app.register(GQL, {
        schema: e.schema,
        context: req => e.createContext(req)
        ide: 'graphiql',
      })

      await app.listen(e.settings.port)

      console.log(
        `Server listening at http://localhost:${e.settings.port}/graphiql`
      )
    },
    stop() {
      return app.close()
    },
  }
})
```

**Accessing the default express instance to do some stuff**

```js
server.custom((e) => {
  e.defaultServer.instance.use(/*some custom middleware*/)

  return e.defaultServer
})
```

#### TODO

- [ ] docs
- [ ] tests
