### PR TITLE
docs: more accessible initial tutorial aside

### DIFF
--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -14,7 +14,7 @@
 
 ## 8. ... -->
 
-> For this tutorial we will use Prisma with PostgreSQL. Install PostgreSQL if needed and then get its connection URL. Check out [our postgresql setup guide](references/recipes?id=local-postgresql) if unsure.
+> For this tutorial we will use PostgreSQL as our database. Install PostgreSQL if needed and then get its connection URL. Check out [our postgresql setup guide](references/recipes?id=local-postgresql) if unsure.
 
 ## Scaffold Project
 


### PR DESCRIPTION
I suggest to remove the mention of Prisma here as Nexus newcomers at this point shouldn't care that Prisma is used (the extreme case is that they don't even know what Prisma is, so including it might be confusing).