### PR TITLE
refactor: add-to-context typegen on build

### DIFF
--- a/src/framework/schema/config.ts
+++ b/src/framework/schema/config.ts
@@ -1,5 +1,5 @@
 import * as Nexus from '@nexus/schema'
-import { stripIndents, stripIndent } from 'common-tags'
+import { stripIndent, stripIndents } from 'common-tags'
 import * as fs from 'fs-jetpack'
 import * as Lo from 'lodash'
 import * as Plugin from '../../lib/plugin'
@@ -109,18 +109,6 @@ function withAutoTypegenConfig(
       }
     `)
     config.contextType = 'NexusContext'
-
-    // Integrate user's app calls to app.addToContext
-    const addToContextCallResults: string[] = process.env
-      .NEXUS_TYPEGEN_ADD_CONTEXT_RESULTS
-      ? JSON.parse(process.env.NEXUS_TYPEGEN_ADD_CONTEXT_RESULTS)
-      : []
-
-    const addToContextInterfaces = addToContextCallResults
-      .map(result => `interface Context ${result}`)
-      .join('\n\n')
-
-    config.imports.push(addToContextInterfaces)
 
     // Integrate plugin context contributions
     for (const p of plugins) {

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -87,9 +87,14 @@ export function findDirContainingFileRecurisvelyUpwardSync(
  * For more details that motivated this utility refer to the originating issue
  * https://github.com/prisma-labs/nexus-prisma/issues/453.
  */
-export const hardWriteFileSync = (filePath: string, data: string): void => {
+export function hardWriteFileSync(filePath: string, data: string) {
   FS.remove(Path.dirname(filePath))
   FS.write(filePath, data)
+}
+
+export async function hardWriteFile(filePath: string, data: string) {
+  await FS.removeAsync(Path.dirname(filePath))
+  await FS.writeAsync(filePath, data)
 }
 
 /**


### PR DESCRIPTION
This refactor removes the last place where addToContext type extraction
was integrated outside the new lib module. There was a wacky environment
variable system in use for passing the data at build time from build
module to nexus schema config module. Now the system used at build is
the same one used in dev!