### PR TITLE
feat(schema): graphql sdl generate setting

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1232,6 +1232,7 @@ schema.addToContext<FastifyRequest>(_req => {
   playground?: boolean
   schema?: {
     connections?: {} // TODO
+    generateGraphQLSDLFile?: false | string
   }
   logger?: {
     level?: 'trace' | 'debug' | 'info' | 'warn' | 'critical' | 'fatal'
@@ -1274,6 +1275,15 @@ schema.addToContext<FastifyRequest>(_req => {
   - Is `NEXUS_HOST` environment variable set? Then that.
   - Is `HOST` environment variable set? Then that.
   - Else `0.0.0.0`
+
+* `schema.generateGraphQLSDLFile`
+  Should a [GraphQL SDL file](https://www.prisma.io/blog/graphql-sdl-schema-definition-language-6755bcb9ce51) be generated when the app is built and to where?
+
+  A relative path is interpreted as being relative to the project directory. Intermediary folders are created automatically if they do not exist already.
+
+  **Default**
+
+  `false`
 
 * `schema.connections`
 

--- a/src/framework/schema/config.ts
+++ b/src/framework/schema/config.ts
@@ -1,21 +1,23 @@
-import * as Nexus from '@nexus/schema'
+import * as NexusSchema from '@nexus/schema'
 import { stripIndent, stripIndents } from 'common-tags'
 import * as fs from 'fs-jetpack'
 import * as Lo from 'lodash'
+import { isAbsolute } from 'path'
+import { mustLoadDataFromParentProcess } from '../../lib/layout/layout'
 import * as Plugin from '../../lib/plugin'
+import { Param1 } from '../../lib/utils'
 import { log } from './logger'
-import {
-  shouldExitAfterGenerateArtifacts,
-  shouldGenerateArtifacts,
-} from './nexus'
+import { SettingsData, SettingsInput } from './schema'
 
-export type NexusConfig = Nexus.core.SchemaConfig
+type NexusConfig = NexusSchema.core.SchemaConfig
+
 export const NEXUS_DEFAULT_TYPEGEN_PATH = fs.path(
   'node_modules',
   '@types',
   'typegen-nexus',
   'index.d.ts'
 )
+
 export const NEXUS_DEFAULT_RUNTIME_CONTEXT_TYPEGEN_PATH = fs.path(
   'node_modules',
   '@types',
@@ -23,29 +25,30 @@ export const NEXUS_DEFAULT_RUNTIME_CONTEXT_TYPEGEN_PATH = fs.path(
   'index.d.ts'
 )
 
-export function createInternalConfig(
-  plugins: Plugin.RuntimeContributions[]
+export function createNexusSchemaConfig(
+  frameworkPlugins: Plugin.RuntimeContributions[],
+  settings: SettingsData
 ): NexusConfig {
-  const defaultConfig = createDefaultNexusConfig()
+  const layout = mustLoadDataFromParentProcess()
 
-  // Merge the plugin nexus plugins
-  defaultConfig.plugins = defaultConfig.plugins ?? []
-
-  for (const plugin of plugins) {
-    defaultConfig.plugins.push(...(plugin.nexus?.plugins ?? []))
+  // Process graphQL SDL output setting
+  let outputSchema: string | false
+  if (
+    settings.generateGraphQLSDLFile === undefined ||
+    settings.generateGraphQLSDLFile === false
+  ) {
+    outputSchema = false
+  } else {
+    if (isAbsolute(settings.generateGraphQLSDLFile)) {
+      outputSchema = settings.generateGraphQLSDLFile
+    } else {
+      outputSchema = layout.projectPath(settings.generateGraphQLSDLFile)
+    }
   }
 
-  const finalConfig = withAutoTypegenConfig(defaultConfig, plugins)
-
-  log.trace('config built', { nexusConfig: finalConfig })
-
-  return finalConfig
-}
-
-function createDefaultNexusConfig(): NexusConfig {
-  return {
+  const baseConfig: NexusConfig = {
     outputs: {
-      schema: false,
+      schema: outputSchema,
       typegen: NEXUS_DEFAULT_TYPEGEN_PATH,
     },
     typegenAutoConfig: {
@@ -54,7 +57,22 @@ function createDefaultNexusConfig(): NexusConfig {
     shouldGenerateArtifacts: shouldGenerateArtifacts(),
     shouldExitAfterGenerateArtifacts: shouldExitAfterGenerateArtifacts(),
     types: [],
+    plugins: [],
   }
+
+  baseConfig.plugins!.push(...processConnectionsConfig(settings))
+
+  // Merge the plugin nexus plugins
+  for (const frameworkPlugin of frameworkPlugins) {
+    const schemaPlugins = frameworkPlugin.nexus?.plugins ?? []
+    baseConfig.plugins!.push(...schemaPlugins)
+  }
+
+  const finalConfig = withAutoTypegenConfig(baseConfig, frameworkPlugins)
+
+  log.trace('config built', { config: finalConfig })
+
+  return finalConfig
 }
 
 function withAutoTypegenConfig(
@@ -96,7 +114,7 @@ function withAutoTypegenConfig(
   // curreent use-case, fairly basic, integrated into the auto system, here:
   // https://github.com/prisma-labs/nexus/issues/323
   nexusConfig.typegenConfig = async (schema, outputPath) => {
-    const configurator = await Nexus.core.typegenAutoConfig(
+    const configurator = await NexusSchema.core.typegenAutoConfig(
       typegenAutoConfigObject
     )
     const config = await configurator(schema, outputPath)
@@ -139,4 +157,68 @@ function withAutoTypegenConfig(
   }
 
   return nexusConfig
+}
+
+export function shouldGenerateArtifacts(): boolean {
+  return process.env.NEXUS_SHOULD_GENERATE_ARTIFACTS === 'true'
+    ? true
+    : process.env.NEXUS_SHOULD_GENERATE_ARTIFACTS === 'false'
+    ? false
+    : Boolean(!process.env.NODE_ENV || process.env.NODE_ENV === 'development')
+}
+
+export function shouldExitAfterGenerateArtifacts(): boolean {
+  return process.env.NEXUS_SHOULD_EXIT_AFTER_GENERATE_ARTIFACTS === 'true'
+    ? true
+    : false
+}
+
+type ConnectionPluginConfig = NonNullable<
+  Param1<typeof NexusSchema.connectionPlugin>
+>
+
+export type ConnectionConfig = Omit<ConnectionPluginConfig, 'nexusFieldName'>
+
+/**
+ * Process the schema connection settings into nexus schema relay connection
+ * plugins.
+ */
+function processConnectionsConfig(
+  settings: SettingsInput
+): NexusSchema.core.NexusPlugin[] {
+  if (settings.connections === undefined) {
+    return [defaultConnectionPlugin({})]
+  }
+
+  const instances: NexusSchema.core.NexusPlugin[] = []
+  const {
+    default: defaultTypeConfig,
+    ...customTypesConfig
+  } = settings.connections
+
+  for (const [name, config] of Object.entries(customTypesConfig)) {
+    if (config) {
+      instances.push(
+        NexusSchema.connectionPlugin({
+          nexusFieldName: name,
+          ...config,
+        })
+      )
+    }
+  }
+
+  if (defaultTypeConfig) {
+    instances.push(defaultConnectionPlugin(defaultTypeConfig))
+  }
+
+  return instances
+}
+
+function defaultConnectionPlugin(
+  configBase: ConnectionConfig
+): NexusSchema.core.NexusPlugin {
+  return NexusSchema.connectionPlugin({
+    ...configBase,
+    nexusFieldName: 'connection',
+  })
 }

--- a/src/framework/schema/index.ts
+++ b/src/framework/schema/index.ts
@@ -1,2 +1,1 @@
-export { createInternalConfig } from './config'
 export { create, Schema, SettingsData, SettingsInput } from './schema'

--- a/src/framework/schema/nexus.ts
+++ b/src/framework/schema/nexus.ts
@@ -115,17 +115,3 @@ export function createNexusSingleton() {
     __types,
   }
 }
-
-export function shouldGenerateArtifacts(): boolean {
-  return process.env.NEXUS_SHOULD_GENERATE_ARTIFACTS === 'true'
-    ? true
-    : process.env.NEXUS_SHOULD_GENERATE_ARTIFACTS === 'false'
-    ? false
-    : Boolean(!process.env.NODE_ENV || process.env.NODE_ENV === 'development')
-}
-
-export function shouldExitAfterGenerateArtifacts(): boolean {
-  return process.env.NEXUS_SHOULD_EXIT_AFTER_GENERATE_ARTIFACTS === 'true'
-    ? true
-    : false
-}

--- a/src/framework/schema/schema.ts
+++ b/src/framework/schema/schema.ts
@@ -19,7 +19,7 @@ export type SettingsInput = {
     [typeName: string]: ConnectionConfig | undefined | false
   }
   /**
-   * Should a GraphQL SDL file be generated when the app is built and to where?
+   * Should a [GraphQL SDL file](https://www.prisma.io/blog/graphql-sdl-schema-definition-language-6755bcb9ce51) be generated when the app is built and to where?
    *
    * A relative path is interpreted as being relative to the project directory.
    * Intermediary folders are created automatically if they do not exist


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/284476/76252080-96fe2380-621e-11ea-99cc-e722c3bada90.png)


closes #427
closes #448

This PR replaces #448 by @mohe2015 (thanks @mohe2015!). This is because:

1. We want to ship the initial version as a new opt-in schema setting
2. This part of the codebase is really a terrible mess and was hard
   enough for me to navigate let alone guide an external contributor
   through it.

Why opt-in?

- Because its not obvious that generating this file all the time is the
  best default.
- We can add a default soon
- In a backwards compatible way (pre 1.0 so not a big deal though)

Why explicit path?

- Because its not obvious that `generated/schema.graphql` is the best
  default. For example `api.grpahql` in project root?
- We can add a default soon
- In a backwards compatible way (pre 1.0 so not a big deal though)

Other points

- I thought about enabling by default into
  `node_modules/.nexus/api.graphql`. This would be transparent to users
  that don't want it. Yet it would allow users who do want it for
  tooling reasons to use it with zero config. Finally though, users who
  do want it and do want to check it into version control would need to
  explicitly configure it. Its not clear to me how import the
  present-but-not-tracked-just-for-tooling use-case is yet. If we took
  this route we'd be setting a kind of contract with users and adding
  latency to each `makeSchema` iteration. So its not really free to take
  this path, and, hence, did not yet.

- No tests yet, but soon.

- I hesitated about where this setting should live. At the root level, or under `schema`. I ultimately went with `schema` because:
  1. Adding more settings noise at the root seems significant
  2. We've essentially stated we're not sure if this setting is that important to be on otherwise we'd have turned it on by default. If the setting is not important enough to be enabled by default it is not important enough to own a spot at the root level of settings, was my logic.
<br>

- Finally, a tradition that is emerging, which is, complain about this
part of the codebase every time I have to touch it. Its a mess. :D
Thanks to our new e2e test system I hope we can clean it up soon.

#### TODO

- [x] docs
- [x] ~tests~