### PR TITLE
fix(build): use layout only in dev

### DIFF
--- a/src/framework/schema/config.ts
+++ b/src/framework/schema/config.ts
@@ -29,26 +29,11 @@ export function createNexusSchemaConfig(
   frameworkPlugins: Plugin.RuntimeContributions[],
   settings: SettingsData
 ): NexusConfig {
-  const layout = mustLoadDataFromParentProcess()
-
-  // Process graphQL SDL output setting
-  let outputSchema: string | false
-  if (
-    settings.generateGraphQLSDLFile === undefined ||
-    settings.generateGraphQLSDLFile === false
-  ) {
-    outputSchema = false
-  } else {
-    if (isAbsolute(settings.generateGraphQLSDLFile)) {
-      outputSchema = settings.generateGraphQLSDLFile
-    } else {
-      outputSchema = layout.projectPath(settings.generateGraphQLSDLFile)
-    }
-  }
+  const outputSchemaPath = getOutputSchemaPath(settings)
 
   const baseConfig: NexusConfig = {
     outputs: {
-      schema: outputSchema,
+      schema: outputSchemaPath,
       typegen: NEXUS_DEFAULT_TYPEGEN_PATH,
     },
     typegenAutoConfig: {
@@ -221,4 +206,29 @@ function defaultConnectionPlugin(
     ...configBase,
     nexusFieldName: 'connection',
   })
+}
+
+function getOutputSchemaPath(settings: SettingsInput) {
+  if (process.env.NEXUS_STAGE !== 'dev') {
+    return false
+  }
+
+  const layout = mustLoadDataFromParentProcess() // Using layout at runtime and in "prod"
+  // Process graphQL SDL output setting
+  let outputSchema: string | false
+
+  if (
+    settings.generateGraphQLSDLFile === undefined ||
+    settings.generateGraphQLSDLFile === false
+  ) {
+    outputSchema = false
+  } else {
+    if (isAbsolute(settings.generateGraphQLSDLFile)) {
+      outputSchema = settings.generateGraphQLSDLFile
+    } else {
+      outputSchema = layout.projectPath(settings.generateGraphQLSDLFile)
+    }
+  }
+
+  return outputSchema
 }

--- a/src/framework/schema/schema.ts
+++ b/src/framework/schema/schema.ts
@@ -110,8 +110,7 @@ export function create({
           plugins,
           state.settings
         )
-        const schema = makeSchema(nexusSchemaConfig)
-        return schema
+        return makeSchema(nexusSchemaConfig)
       },
       settings: {
         data: state.settings,

--- a/src/lib/watcher/runner.ts
+++ b/src/lib/watcher/runner.ts
@@ -25,12 +25,6 @@ register({
 ;(async function() {
   const layout = await Layout.create()
 
-  // TODO: Find more elegant way to do that?
-  process.env = {
-    ...process.env,
-    ...Layout.saveDataForChildProcess(layout),
-  }
-
   log.trace('starting context type extraction')
 
   runAddToContextExtractorAsWorkerIfPossible(layout)

--- a/src/utils/artifact-generation.ts
+++ b/src/utils/artifact-generation.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'child_process'
 import * as FS from 'fs-jetpack'
 import { rootLogger } from './logger'
+import { fatal } from './process'
 
 const log = rootLogger.child('typegen')
 
@@ -21,6 +22,11 @@ export async function generateArtifacts(startScript: string): Promise<void> {
   if (result.error) {
     log.trace('...had error trying to start the typegen process')
     throw result.error
+  }
+
+  if (result.stderr) {
+    log.trace('...had error trying to start the typegen process')
+    fatal(result.stderr)
   }
 
   // Handling no-hoist problem

--- a/src/utils/tsc.ts
+++ b/src/utils/tsc.ts
@@ -116,18 +116,35 @@ export function readTsConfig(layout: Layout): ts.ParsedCommandLine {
 }
 
 export function createTSProgram(
-  layout: Layout
+  layout: Layout,
+  opts?: {
+    withCache?: boolean
+  }
 ): ts.EmitAndSemanticDiagnosticsBuilderProgram {
   const tsConfig = readTsConfig(layout)
+  const cacheOptions = opts?.withCache
+    ? {
+        tsBuildInfoFile: getTSIncrementalFilePath(layout),
+        incremental: true,
+      }
+    : {}
+
   const program = ts.createIncrementalProgram({
     rootNames: tsConfig.fileNames,
     options: {
-      incremental: true,
-      tsBuildInfoFile: './node_modules/.nexus/cache.tsbuildinfo',
+      ...cacheOptions,
       ...tsConfig.options,
     },
   })
   return program
+}
+
+export function deleteTSIncrementalFile(layout: Layout) {
+  fs.remove(getTSIncrementalFilePath(layout))
+}
+
+export function getTSIncrementalFilePath(layout: Layout) {
+  return layout.projectPath('node_modules', '.nexus', 'cache.tsbuildinfo')
 }
 
 /**


### PR DESCRIPTION
### Fixes

- Make sure build errors are caught and make the command fail
- Do not generate the schema file in "prod"
- Delete the TS incremental file when running `build` to always start from a clean slate
- Refactor `createTSProgram`