### PR TITLE
fix: don't look for parent package.json on init

### DIFF
--- a/src/lib/layout/layout.ts
+++ b/src/lib/layout/layout.ts
@@ -268,32 +268,33 @@ export async function scanProjectType(): Promise<
   | { type: 'unknown' | 'new' }
   | {
       type: 'NEXUS_project' | 'node_project'
-      packageJson: {}
-      packageJsonLocation: { path: string; dir: string }
+      packageJson: PackageJson
+      packageJsonLocation: string
     }
 > {
-  const packageJsonLocation = findPackageJson()
+  const packageJsonLocation = Path.join(process.cwd(), 'package.json')
 
-  if (packageJsonLocation === null) {
+  if (!FS.exists(packageJsonLocation)) {
     if (await isEmptyCWD()) {
       return { type: 'new' }
     }
     return { type: 'unknown' }
   }
 
-  const packageJson = FS.read(packageJsonLocation.path, 'json')
-  if (packageJson?.dependencies?.['nexus-future']) {
+  const packageJson: PackageJson = FS.read(packageJsonLocation, 'json')
+
+  if (packageJson.dependencies?.['nexus-future']) {
     return {
       type: 'NEXUS_project',
-      packageJson: packageJsonLocation,
-      packageJsonLocation: packageJsonLocation,
+      packageJson,
+      packageJsonLocation,
     }
   }
 
   return {
     type: 'node_project',
-    packageJson: packageJsonLocation,
-    packageJsonLocation: packageJsonLocation,
+    packageJson,
+    packageJsonLocation,
   }
 }
 


### PR DESCRIPTION
## Description

@huv1k is having trouble using `npx nexus-future`. The current code must probably be finding some `package.json` in some of its parent directories, that he cannot find.

The goal is not to create a single hotfix for him, but rather to generally make the checks less strict.

I think it's important that we don't block people as much as possible on the `init` command.

**This PR makes the `init` command only look for a `package.json` in the `CWD`.**

Question for you though @jasonkuhrt: What do you think could be the problems resulting from not looking at parent directories? Hoisted deps to parent node projects?