### PR TITLE
feat: onBeforeWatcherStartOrRestart hook

### DIFF
--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -41,15 +41,19 @@ export class Dev implements Command {
       generate: {},
       dev: {
         addToWatcherSettings: {},
-        async onBeforeWatcherRestart(change) {
+        async onBeforeWatcherStartOrRestart(change) {
           if (
+            change.type === 'init' ||
             change.type === 'add' ||
             change.type === 'addDir' ||
             change.type === 'unlink' ||
             change.type === 'unlinkDir'
           ) {
+            log.debug('recalcLayout')
             const layout = await Layout.create()
-            Object.assign(process.env, Layout.saveDataForChildProcess(layout))
+            return {
+              environmentAdditions: Layout.saveDataForChildProcess(layout),
+            }
           }
         },
       },
@@ -57,7 +61,7 @@ export class Dev implements Command {
 
     await createWatcher({
       plugins: [layoutPlugin].concat(plugins.map(p => p.hooks)),
-      layout: layout,
+      sourceRoot: layout.sourceRoot,
     })
   }
 }

--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -35,8 +35,28 @@ export class Dev implements Command {
 
     log.info('start', { version: ownPackage.version })
 
+    const layoutPlugin: Plugin.WorktimeHooks = {
+      build: {},
+      create: {},
+      generate: {},
+      dev: {
+        addToWatcherSettings: {},
+        async onBeforeWatcherRestart(change) {
+          if (
+            change.type === 'add' ||
+            change.type === 'addDir' ||
+            change.type === 'unlink' ||
+            change.type === 'unlinkDir'
+          ) {
+            const layout = await Layout.create()
+            Object.assign(process.env, Layout.saveDataForChildProcess(layout))
+          }
+        },
+      },
+    }
+
     await createWatcher({
-      plugins: plugins.map(p => p.hooks),
+      plugins: [layoutPlugin].concat(plugins.map(p => p.hooks)),
       layout: layout,
     })
   }

--- a/src/lib/layout/index.ts
+++ b/src/lib/layout/index.ts
@@ -6,6 +6,7 @@ export {
   findAppModule,
   Layout,
   loadDataFromParentProcess,
+  mustLoadDataFromParentProcess,
   relativeTranspiledImportPath,
   saveDataForChildProcess,
   scanProjectType,

--- a/src/lib/layout/layout.ts
+++ b/src/lib/layout/layout.ts
@@ -328,6 +328,12 @@ export function saveDataForChildProcess(
   }
 }
 
+/**
+ * Load the layout data from a serialized version stored in the environment. If
+ * it is not found then a warning will be logged and it will be recalculated.
+ * For this reason the function is async however under normal circumstances it
+ * should be as-if sync.
+ */
 export async function loadDataFromParentProcess(): Promise<Layout> {
   const savedData: undefined | string = process.env[ENV_VAR_DATA_NAME]
   if (!savedData) {

--- a/src/lib/plugin/index.ts
+++ b/src/lib/plugin/index.ts
@@ -6,7 +6,7 @@ import { TestContextCore } from '../../runtime/testing'
 import * as Logger from '../logger'
 import * as PackageManager from '../package-manager'
 import { run, runSync } from '../process'
-import { ChangeEvent } from '../watcher'
+import { ChangeEvent, RunnerOptions } from '../watcher'
 import * as Chokidar from '../watcher/chokidar'
 export * from './import'
 export * from './load'
@@ -39,7 +39,10 @@ export type WorktimeHooks = {
   }
   dev: {
     onStart?: SideEffector
-    onBeforeWatcherRestart?: (change: ChangeEvent) => MaybePromise
+    onBeforeWatcherRestart?: SideEffector
+    onBeforeWatcherStartOrRestart?: (
+      change: ChangeEvent
+    ) => MaybePromise<void | RunnerOptions>
     onAfterWatcherRestart?: SideEffector
     onFileWatcherEvent?: Chokidar.FileWatcherEventCallback
     addToWatcherSettings: {

--- a/src/lib/plugin/index.ts
+++ b/src/lib/plugin/index.ts
@@ -40,9 +40,8 @@ export type WorktimeHooks = {
   dev: {
     onStart?: SideEffector
     onBeforeWatcherRestart?: SideEffector
-    onBeforeWatcherStartOrRestart?: (
-      change: ChangeEvent
-    ) => MaybePromise<void | RunnerOptions>
+    //prettier-ignore
+    onBeforeWatcherStartOrRestart?: (change: ChangeEvent) => MaybePromise<void | RunnerOptions>
     onAfterWatcherRestart?: SideEffector
     onFileWatcherEvent?: Chokidar.FileWatcherEventCallback
     addToWatcherSettings: {

--- a/src/lib/plugin/index.ts
+++ b/src/lib/plugin/index.ts
@@ -6,6 +6,7 @@ import { TestContextCore } from '../../runtime/testing'
 import * as Logger from '../logger'
 import * as PackageManager from '../package-manager'
 import { run, runSync } from '../process'
+import { ChangeEvent } from '../watcher'
 import * as Chokidar from '../watcher/chokidar'
 export * from './import'
 export * from './load'
@@ -38,7 +39,7 @@ export type WorktimeHooks = {
   }
   dev: {
     onStart?: SideEffector
-    onBeforeWatcherRestart?: SideEffector
+    onBeforeWatcherRestart?: (change: ChangeEvent) => MaybePromise
     onAfterWatcherRestart?: SideEffector
     onFileWatcherEvent?: Chokidar.FileWatcherEventCallback
     addToWatcherSettings: {

--- a/src/lib/watcher/chokidar.ts
+++ b/src/lib/watcher/chokidar.ts
@@ -9,6 +9,13 @@ import { rootLogger } from '../nexus-logger'
 
 const log = rootLogger.child('dev').child('watcher')
 
+type ChangeType = 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir'
+
+export interface ChangeEvent {
+  type: ChangeType
+  file: string
+}
+
 export type FileWatcher = chokidar.FSWatcher & {
   /**
    * Adds a file to be watched without triggering the 'add' events
@@ -19,7 +26,7 @@ export type FileWatcher = chokidar.FSWatcher & {
 }
 
 export type FileWatcherEventCallback = (
-  eventName: 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir',
+  eventName: ChangeType,
   path: string,
   stats: fs.Stats | undefined,
   watcher: {

--- a/src/lib/watcher/link.ts
+++ b/src/lib/watcher/link.ts
@@ -5,14 +5,24 @@ import { Message, ModuleRequiredMessage } from './ipc'
 
 const log = rootLogger.child('dev').child('link')
 
-interface Options {
+interface ChangeableOptions {
   environmentAdditions?: Record<string, string>
+}
+
+interface Options extends ChangeableOptions {
   onRunnerImportedModule?: (data: ModuleRequiredMessage['data']) => void
   onServerListening?: () => void
 }
 
 export class Link {
   constructor(private options: Options) {}
+
+  updateOptions(options: ChangeableOptions) {
+    this.options = {
+      ...this.options,
+      ...options,
+    }
+  }
 
   async startOrRestart() {
     log.trace('startOrRestart requested')

--- a/src/lib/watcher/runner.ts
+++ b/src/lib/watcher/runner.ts
@@ -26,7 +26,7 @@ const tsNodeRegister = tsNode.register({
 main()
 
 async function main() {
-  const layout = await Layout.create()
+  const layout = Layout.mustLoadDataFromParentProcess()
 
   runAddToContextExtractorAsWorkerIfPossible(layout.data)
 

--- a/src/lib/watcher/types.ts
+++ b/src/lib/watcher/types.ts
@@ -1,5 +1,4 @@
 import { ForkOptions } from 'child_process'
-import { Layout } from '../layout'
 import * as Plugin from '../plugin'
 
 export interface Compiler {
@@ -55,7 +54,7 @@ interface StringOpts {
 }
 
 export interface Opts extends BooleanOpts, StringOpts {
-  layout: Layout
+  sourceRoot: string
   log?: any
   watch?: string
   stdio?: ForkOptions['stdio']

--- a/src/lib/watcher/watcher.ts
+++ b/src/lib/watcher/watcher.ts
@@ -193,7 +193,7 @@ export function createWatcher(options: Options): Promise<void> {
       }
       restarting = true
       clearConsole()
-      log.trace('hook', { name: 'beforeWatcherRestart' })
+      log.trace('hook', { name: 'beforeWatcherStartOrRestart' })
       for (const plugin of plugins) {
         const runnerChanges = await plugin.dev.onBeforeWatcherStartOrRestart?.(
           change
@@ -202,6 +202,10 @@ export function createWatcher(options: Options): Promise<void> {
           link.updateOptions(runnerChanges)
         }
       }
+      log.trace('hook', { name: 'beforeWatcherRestart' })
+      plugins.forEach(p => {
+        p.dev.onBeforeWatcherRestart?.()
+      })
       log.info('restarting', change as any)
       if (change.file === compiler.tsConfigPath) {
         log.trace('reinitializing TS compilation')


### PR DESCRIPTION
closes #91

Alt name:

```
feat: onBeforeWatcherStartOrRestart hook
```

- allow async work before watcher start
- allow async work before watcher restart
- allow worker to impact runner (so far: env)
- allow worker to know if restart is due to plugin


Before:

<img width="659" alt="Screen Shot 2020-03-30 at 12 27 29 PM" src="https://user-images.githubusercontent.com/284476/77941478-39428180-7288-11ea-8667-a3afb44ff57c.png">


After:

<img width="661" alt="Screen Shot 2020-03-30 at 12 27 01 PM" src="https://user-images.githubusercontent.com/284476/77941479-39db1800-7288-11ea-85b8-3f9b962b19af.png">

After with e.g. add file:

<img width="693" alt="Screen Shot 2020-03-30 at 1 12 19 PM" src="https://user-images.githubusercontent.com/284476/77941477-38a9eb00-7288-11ea-9e85-f44c63997cc8.png">
